### PR TITLE
Add branch name to build-info

### DIFF
--- a/app/components/build-branch.js
+++ b/app/components/build-branch.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  build: null
+});

--- a/app/styles/components/_build_header.sass
+++ b/app/styles/components/_build_header.sass
@@ -37,6 +37,7 @@
     .BuildInfo-started,
     .BuildInfo-duration,
     .BuildInfo-comparison,
+    .BuildInfo-branch
       float: left
       padding-left: 12px
 

--- a/app/templates/components/build-branch.hbs
+++ b/app/templates/components/build-branch.hbs
@@ -1,0 +1,1 @@
+{{fa-icon 'code-fork'}} {{build.branch}}

--- a/app/templates/components/build-info.hbs
+++ b/app/templates/components/build-info.hbs
@@ -1,5 +1,6 @@
 <div class="BuildInfo-started">{{build-started build=build}}</div>
 <div class="BuildInfo-duration">{{build-duration build=build}}</div>
+<div class="BuildInfo-branch">{{build-branch build=build}}</div>
 {{#if showComparisonInfo}}
   <div class="BuildInfo-comparison">{{build-comparison-info build=build}}</div>
 {{/if}}

--- a/tests/integration/components/build-branch-test.js
+++ b/tests/integration/components/build-branch-test.js
@@ -1,0 +1,22 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent(
+  'build-branch',
+  'Integration: BuildBranchComponent',
+  {
+    integration: true
+  },
+  function() {
+    it('renders', function() {
+      this.set('build', { branch: 'foo' })
+      this.render(hbs`{{build-branch build=build}}`);
+      expect(this.$().text().trim()).to.equal('foo');
+    });
+  }
+);


### PR DESCRIPTION
Found myself looking for this info quite a bit today, and got tired of hitting “back” to figure out what branch I was looking at.

I tried to follow the conventions that I saw in the project. If you would rather I just add it to the template (instead of creating a component), I don’t mind updating.