### PR TITLE
fastboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,38 @@ yarn run start
 
 Then, access [http://dev.percy.local:4200](http://dev.percy.local:4200)
 
+### Using the production api with full oauth flow
+
+Configure redirect pattern `https://percy.io/api/auth/github/callback` => `http://dev.percy.local:4200/api/auth/github/callback` with switcheroo chrome extension https://github.com/ranjez/Switcheroo
+
+#### In fastboot mode
+
+To start percy in fastboot mode:
+
+If you have backend running locally:
+
+```bash
+PERCY_WEB_API_HOST=http://dev.percy.local:9090 npm run start
+```
+
+To connect to production backend:
+
+```bash
+PERCY_WEB_API_HOST=https://percy.io npm run start
+```
+
+To run fastboot tests:
+
+```bash
+npm run fastboot:test
+```
+
+Debugging:
+
+```bash
+PERCY_WEB_API_HOST=https://percy.io node --inspect --debug-brk node_modules/ember-cli/bin/ember server
+```
+
 ## Run tests
 
 ```bash

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,17 +3,28 @@ import DS from 'ember-data';
 import utils from 'percy-web/lib/utils';
 
 export default DS.JSONAPIAdapter.extend({
+  fastboot: Ember.inject.service(),
+
   namespace: 'api/v1',
   adminMode: Ember.inject.service(),
 
   headers: Ember.computed(function() {
-    let headers = {};
+    if (this.get('fastboot.isFastBoot')) {
+      let headers = this.get('fastboot.request.headers');
+      if (headers.headers.cookie) {
+        return {'Cookie': headers.headers.cookie};
+      } else {
+        return {};
+      }
+    } else {
+      let headers = {};
 
-    let percyMode = this.get('adminMode').get();
-    if (percyMode) {
-      headers['X-Percy-Mode'] = percyMode;
+      let percyMode = this.get('adminMode').get();
+      if (percyMode) {
+        headers['X-Percy-Mode'] = percyMode;
+      }
+      return headers;
     }
-    return headers;
   }),
 
   isInvalid(status) {

--- a/app/authenticators/custom.js
+++ b/app/authenticators/custom.js
@@ -5,68 +5,73 @@ import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 export default BaseAuthenticator.extend({
   store: Ember.inject.service(),
   analytics: Ember.inject.service(),
-  restore() {
-    let store = this.get('store');
+  fastboot: Ember.inject.service(),
+
+  restore(data) {
     return new Ember.RSVP.Promise((resolve, reject) => {
-      store.queryRecord('user', {}).then((userRecord) => {
-        if (window.Intercom) {
-          window.Intercom('update', {
-            name: userRecord.get('name'),
-            email: userRecord.get('email'),
-            created_at: userRecord.get('createdAt').getTime() / 1000,
-          });
+        if (!this._validate(data)) {
+          reject();
+        } else {
+          resolve(data);
         }
-        this.get('analytics').identifyUser(userRecord);
-        resolve({user: userRecord});
-      }, reject);
-    });
+      });
   },
   authenticate(options) {
     let store = this.get('store');
     return new Ember.RSVP.Promise((resolve) => {
       store.queryRecord('user', {}).then((userRecord) => {
-        if (window.Intercom) {
-          window.Intercom('update', {
-            name: userRecord.get('name'),
-            email: userRecord.get('email'),
-            created_at: userRecord.get('createdAt').getTime() / 1000,
-          });
+        if (!this.get('fastboot.isFastBoot')) {
+          if (window.Intercom) {
+            window.Intercom('update', {
+              name: userRecord.get('name'),
+              email: userRecord.get('email'),
+              created_at: userRecord.get('createdAt').getTime() / 1000,
+            });
+          }
         }
         this.get('analytics').identifyUser(userRecord);
-        resolve({user: userRecord});
+        resolve({_user: userRecord});
       }, () => {
         // Build params if given a custom final redirect location.
         var finalRedirect;
         options = options || {};
-        if (options.redirectTo) {
-          var parser = document.createElement('a');
-          parser.href = window.location.href;
-          parser.pathname = '/login';
-          parser.search = '?redirect_to=' + encodeURIComponent(options.redirectTo);
-          finalRedirect = parser.href;
-        } else {
-          finalRedirect = '/login';
+
+        if (!this.get('fastboot.isFastBoot')) {
+          if (options.redirectTo) {
+            var parser = document.createElement('a');
+            parser.href = window.location.href;
+            parser.pathname = '/login';
+            parser.search = '?redirect_to=' + encodeURIComponent(options.redirectTo);
+            finalRedirect = parser.href;
+          } else {
+            finalRedirect = '/login';
+          }
+          // Redirect to GitHub auth.
+          window.location = utils.buildApiUrl('login', {params: {redirect_to: finalRedirect}});
         }
-        // Redirect to GitHub auth.
-        window.location = utils.buildApiUrl('login', {params: {redirect_to: finalRedirect}});
       });
     });
   },
   invalidate() {
     return new Ember.RSVP.Promise((resolve, reject) => {
-      Ember.$.ajax({
-        type: 'GET',
-        url: utils.buildApiUrl('logout')
-      }).done((data) => {
-        // If a user clicks Logout, make sure we clear all the persistent storage locations.
-        this.get('analytics').invalidate();
-        if (window.localStorage) {
-          window.localStorage.clear();
-        }
-        resolve(data);
-      }).fail(function(xhr) {
-        reject(xhr);
-      });
+      if (!this.get('fastboot.isFastBoot')) {
+        Ember.$.ajax({
+          type: 'GET',
+          url: utils.buildApiUrl('logout')
+        }).done((data) => {
+          // If a user clicks Logout, make sure we clear all the persistent storage locations.
+          this.get('analytics').invalidate();
+          if (window.localStorage) {
+            window.localStorage.clear();
+          }
+          resolve(data);
+        }).fail(function(xhr) {
+          reject(xhr);
+        });
+      }
     });
+  },
+  _validate(data) {
+    return data._user && data._user.login;
   }
 });

--- a/app/authenticators/custom.js
+++ b/app/authenticators/custom.js
@@ -48,6 +48,8 @@ export default BaseAuthenticator.extend({
           }
           // Redirect to GitHub auth.
           window.location = utils.buildApiUrl('login', {params: {redirect_to: finalRedirect}});
+        } else {
+          return Ember.getOwner(this).lookup('router:main').transitionTo('github-login');
         }
       });
     });

--- a/app/components/build-container.js
+++ b/app/components/build-container.js
@@ -46,15 +46,17 @@ export default Ember.Component.extend({
   }).drop(),
 
   restoreSelectedModeColumns: Ember.on('init', function() {
-    let numColumns = localStorage.getItem('numColumns');
+    if (window.localStorage) {
+      let numColumns = localStorage.getItem('numColumns');
 
-    // Cleanup bad data (not a number) in localStorage.
-    if (numColumns && Number(numColumns) === numColumns && numColumns % 1 !== 0) {
-      localStorage.deleteItem('numColumns');
-      return;
-    }
-    if (numColumns) {
-      this.send('selectNumColumns', parseInt(numColumns));
+      // Cleanup bad data (not a number) in localStorage.
+      if (numColumns && Number(numColumns) === numColumns && numColumns % 1 !== 0) {
+        localStorage.deleteItem('numColumns');
+        return;
+      }
+      if (numColumns) {
+        this.send('selectNumColumns', parseInt(numColumns));
+      }
     }
   }),
   actions: {

--- a/app/components/fixed-top-header.js
+++ b/app/components/fixed-top-header.js
@@ -2,4 +2,5 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   session: Ember.inject.service(),
+  currentUser: Ember.inject.service()
 });

--- a/app/components/forms/organization-user-edit.js
+++ b/app/components/forms/organization-user-edit.js
@@ -9,10 +9,9 @@ export default BaseFormComponent.extend({
   classNameBindings: ['classes'],
 
   session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
-  isCurrentUser: Ember.computed('organizationUser', 'currentUser', function() {
-    // TODO: why can't we use Ember.computed.equal for this?
-    return this.get('organizationUser.user.id') === this.get('currentUser.id');
+  currentUser: Ember.inject.service(),
+  isCurrentUser: Ember.computed('organizationUser', 'currentUser.user', function() {
+    return this.get('organizationUser.user.id') === this.get('currentUser.user.id');
   }),
   deleteText: Ember.computed('isCurrentUser', function() {
     if (this.get('isCurrentUser')) {

--- a/app/components/invitation-handler.js
+++ b/app/components/invitation-handler.js
@@ -4,8 +4,7 @@ export default Ember.Component.extend({
   invitation: null,
 
   classNames: ['InvitationHandler'],
-  session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
 
   actions: {
     invalidateSession() {

--- a/app/components/nav-menu.js
+++ b/app/components/nav-menu.js
@@ -5,7 +5,6 @@ export default Ember.Component.extend(TargetApplicationActionsMixin, {
   user: null,
   classes: null,
 
-  session: Ember.inject.service(),
   classNames: ['NavMenu'],
   classNameBindings: ['classes'],
 });

--- a/app/components/organizations/github-integrator.js
+++ b/app/components/organizations/github-integrator.js
@@ -10,8 +10,6 @@ export default Ember.Component.extend({
   classes: null,
 
   store: Ember.inject.service(),
-  session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
 
   waitingForInstallation: false,
   currentIntegration: Ember.computed.alias('organization.githubIntegration'),

--- a/app/components/organizations/github-settings.js
+++ b/app/components/organizations/github-settings.js
@@ -7,8 +7,7 @@ export default Ember.Component.extend({
   classes: null,
 
   store: Ember.inject.service(),
-  session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
 
   changeset: Ember.computed('organization', function() {
     let validator = this.get('validator') || {};
@@ -59,7 +58,7 @@ export default Ember.Component.extend({
     },
     assignBotUser() {
       let changeset = this.get('changeset');
-      changeset.set('githubBotUser', this.get('currentUser'));
+      changeset.set('githubBotUser', this.get('currentUser.user'));
     },
     saveSelection() {
       let organization = this.get('organization');

--- a/app/components/organizations/jump-to-billing.js
+++ b/app/components/organizations/jump-to-billing.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   ],
 
   session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
   actions: {
     chooseOrganization(organization) {
       // Send action directly up to application controller, so we don't have to delegate every

--- a/app/components/organizations/switcher-nav.js
+++ b/app/components/organizations/switcher-nav.js
@@ -5,8 +5,7 @@ export default Ember.Component.extend({
 
   isExpanded: false,
 
-  session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
 
   classNames: ['OrganizationsSwitcherNav'],
   classNameBindings: [
@@ -15,7 +14,7 @@ export default Ember.Component.extend({
 
   actions: {
     toggleSwitcher() {
-      this.get('currentUser.organizations').reload();
+      this.get('currentUser.user.organizations').reload();
       this.toggleProperty('isExpanded');
     },
     hideSwitcher() {

--- a/app/components/organizations/user-card.js
+++ b/app/components/organizations/user-card.js
@@ -4,8 +4,7 @@ export default Ember.Component.extend({
   organizationUser: null,
   classes: null,
 
-  session: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
 
   isExpanded: false,
   classNames: ['OrganizationsUserCard'],

--- a/app/components/sync-repos-section.js
+++ b/app/components/sync-repos-section.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   classes: null,
 
   isPrivateReposExpanded: false,
-  session: Ember.inject.service(),
+  currentUser: Ember.inject.service(),
 
   classNames: ['SyncReposSection', 'Card'],
   classNameBindings: ['classes', 'isPrivateReposExpanded::SyncReposSection--collapsed'],

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -44,7 +44,15 @@ export default {
         path = path.replace('%@', arg);
       });
     }
-    return window.location.origin + path + queryParams;
+    let host;
+    if (config.PERCY_WEB_API_HOST_FASTBOOT) {
+      host = config.PERCY_WEB_API_HOST_FASTBOOT;
+    } else if (window && window.location) {
+      host = window.location.origin;
+    } else {
+      host = 'https://percy.io';
+    }
+    return host + path + queryParams;
   },
   getQueryParam(param) {
     var query = window.location.search.substring(1);

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -45,8 +45,9 @@ export default {
       });
     }
     let host;
-    if (config.PERCY_WEB_API_HOST_FASTBOOT) {
-      host = config.PERCY_WEB_API_HOST_FASTBOOT;
+    if (options.fastboot && options.fastboot.get('isFastBoot')) {
+      let request = options.fastboot.get('request');
+      host = `${request.get('protocol')}://${request.get('host')}`;
     } else if (window && window.location) {
       host = window.location.origin;
     } else {

--- a/app/mixins/authenticated-route-mixin.js
+++ b/app/mixins/authenticated-route-mixin.js
@@ -1,0 +1,8 @@
+import ESAAuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import Ember from 'ember';
+
+var AuthenticatedRouteMixin = Ember.Mixin.create(ESAAuthenticatedRouteMixin, {
+
+});
+
+export default AuthenticatedRouteMixin;

--- a/app/mixins/authenticated-route-mixin.js
+++ b/app/mixins/authenticated-route-mixin.js
@@ -2,7 +2,9 @@ import ESAAuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-r
 import Ember from 'ember';
 
 var AuthenticatedRouteMixin = Ember.Mixin.create(ESAAuthenticatedRouteMixin, {
-
+  authenticationRoute: Ember.computed(function() {
+    return 'github-login';
+  })
 });
 
 export default AuthenticatedRouteMixin;

--- a/app/mixins/reset-scroll.js
+++ b/app/mixins/reset-scroll.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 var ResetScrollMixin = Ember.Mixin.create({
   actions: {
     didTransition() {
-      window.scrollTo(0, 0);
+      if (window && window.scrollTo) {
+        window.scrollTo(0, 0);
+      }
     }
   }
 });

--- a/app/router.js
+++ b/app/router.js
@@ -30,6 +30,10 @@ Router.map(function() {
   this.route('privacy');
   this.route('security');
   this.route('admin');
+  this.route('auth', function() {
+    this.route('failure');
+    this.route('success');
+  });
   this.route('organizations', {path: '/organizations'}, function() {
     this.route('new');
     this.route('organization', {path: '/:organization_id'}, function() {

--- a/app/router.js
+++ b/app/router.js
@@ -18,6 +18,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('login');
+  this.route('github-login');
   this.route('join', {path: '/join/:invite_code'});
   this.route('docs', {path: '/docs'}, function() {
     this.route('page', {path: '*path'});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -9,12 +9,18 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   // https://github.com/simplabs/ember-simple-auth/issues/1048
   sessionInvalidated() {
     if (!Ember.testing) {
-      window.location.replace('/');
+      if (window.location) {
+        window.location.replace('/');
+      } else {
+        this.transitionTo('/');
+      }
     }
   },
 
   beforeModel() {
-    return this._loadCurrentUser();
+    if (this.get('session.isAuthenticated')) {
+      return this._loadCurrentUser();
+    }
   },
 
   sessionAuthenticated() {

--- a/app/routes/auth/failure.js
+++ b/app/routes/auth/failure.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+
+export default Ember.Route.extend(UnauthenticatedRouteMixin);

--- a/app/routes/auth/success.js
+++ b/app/routes/auth/success.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
+
+export default Ember.Route.extend(ApplicationRouteMixin, {
+
+  afterModel() {
+    this.get('session').authenticate('authenticator:custom', {}).then(function() {});
+  }
+});

--- a/app/routes/builds.js
+++ b/app/routes/builds.js
@@ -2,4 +2,9 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
+  currentUser: Ember.inject.service(),
+  setupController: function(controller, model) {
+    this._super(controller, model);
+    controller.set('currentUser', this.get('currentUser'));
+  }
 });

--- a/app/routes/builds.js
+++ b/app/routes/builds.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from 'mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   currentUser: Ember.inject.service(),

--- a/app/routes/github-login.js
+++ b/app/routes/github-login.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import utils from '../lib/utils';
+
+export default Ember.Route.extend(UnauthenticatedRouteMixin, {
+  model() {
+    return {redirectTarget: utils.buildApiUrl('login', {})};
+  }
+});

--- a/app/routes/github-login.js
+++ b/app/routes/github-login.js
@@ -3,7 +3,30 @@ import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-
 import utils from '../lib/utils';
 
 export default Ember.Route.extend(UnauthenticatedRouteMixin, {
+  fastboot: Ember.inject.service(),
+  session: Ember.inject.service(),
+  cookies: Ember.inject.service(),
+
   model() {
-    return {redirectTarget: utils.buildApiUrl('login', {})};
-  }
+    var location;
+    if (this.get('fastboot.isFastBoot')) {
+      let host = this.get('fastboot.request.host');
+      let protocol = this.get('fastboot.request.protocol');
+      location = `${protocol}://${host}`;
+    } else {
+      location = window.location.origin;
+    }
+
+    var fastboot = this.get('fastboot');
+    if (!fastboot.get('isFastBoot')) {
+      var attemptedTransition = this.get('session.attemptedTransition').intent.url;
+      this.get('cookies').write('ember_simple_auth-redirectTarget', attemptedTransition, {
+          path: '/',
+          secure: window.location.protocol === 'https:'
+        });
+    }
+    let loginUrl = utils.buildApiUrl('login', {fastboot});
+    var redirectTarget = `${loginUrl}?redirect_to=${location}/auth/success`;
+    return {redirectTarget};
+  },
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 import ResetScrollMixin from '../mixins/reset-scroll';
 
 export default Ember.Route.extend(ResetScrollMixin, {
+  currentUser: Ember.inject.service(),
+  setupController: function(controller, model) {
+    this._super(controller, model);
+    controller.set('currentUser', this.get('currentUser'));
+  },
   actions: {
     didTransition() {
       this._super.apply(this, arguments);

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -6,18 +6,19 @@ import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-
 
 export default Ember.Route.extend(UnauthenticatedRouteMixin, {
   session: Ember.inject.service(),
+  fastboot: Ember.inject.service(),
 
   afterModel() {
     // Right now location.href is the URL before the transition to the login route has completed.
     // Make sure to pass redirectTo into the authenticator so that we come back to that URL.
     let options = {};
-    if (window && !window.location.href.endsWith('/login')) {
+    if (window && window.location && !window.location.href.endsWith('/login')) {
       options['redirectTo'] = window.location.href;
     } else {
       options['redirectTo'] = '/';
     }
 
-    this.get('session').authenticate('authenticator:custom', options).then(
+    return this.get('session').authenticate('authenticator:custom', options).then(
       function() {
         var finalRedirect = utils.getQueryParam('redirect_to');
         if (finalRedirect) {

--- a/app/routes/organization.js
+++ b/app/routes/organization.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from 'percy-web/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   currentUser: Ember.inject.service(),

--- a/app/routes/organization.js
+++ b/app/routes/organization.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
   intercom: Ember.inject.service(),
 
   afterModel(model) {
@@ -12,6 +12,6 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
       // Safari throws errors while accessing localStorage in private mode.
     }
 
-    this.get('intercom').associateWithCompany(this.get('currentUser'), model);
+    this.get('intercom').associateWithCompany(this.get('currentUser.user'), model);
   },
 });

--- a/app/routes/organization/index.js
+++ b/app/routes/organization/index.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '../../mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   redirect() {

--- a/app/routes/organization/project.js
+++ b/app/routes/organization/project.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '../../mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model(params) {

--- a/app/routes/organization/project/builds/build.js
+++ b/app/routes/organization/project/builds/build.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '../../../../mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   queryParams: {

--- a/app/routes/organization/project/builds/build/snapshot.js
+++ b/app/routes/organization/project/builds/build/snapshot.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from 'percy-web/mixins/authenticated-route-mixin';
 import ResetScrollMixin from 'percy-web/mixins/reset-scroll';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {

--- a/app/routes/organization/project/builds/index.js
+++ b/app/routes/organization/project/builds/index.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '../../../mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   redirect() {
@@ -8,4 +8,3 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     this.transitionTo('organization.project.index', organizationSlug, projectSlug);
   },
 });
-

--- a/app/routes/organization/project/index.js
+++ b/app/routes/organization/project/index.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from '../../../mixins/authenticated-route-mixin';
 import ResetScrollMixin from 'percy-web/mixins/reset-scroll';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {

--- a/app/routes/organizations/organization.js
+++ b/app/routes/organizations/organization.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
   intercom: Ember.inject.service(),
 
   afterModel(model) {
-    this.get('intercom').associateWithCompany(this.get('currentUser'), model);
+    this.get('intercom').associateWithCompany(this.get('currentUser.user'), model);
 
     // Proactively load the currentUserMembership object and return to block rendering until it
     // exists, since we use it to determine what parts of the organization settings the current

--- a/app/services/analytics.js
+++ b/app/services/analytics.js
@@ -2,9 +2,8 @@ import Ember from 'ember';
 import config from '../config/environment';
 
 export default Ember.Service.extend({
-  session: Ember.inject.service(),
   adminMode: Ember.inject.service(),
-  currentUser: Ember.computed.alias('session.data.authenticated.user'),
+  currentUser: Ember.inject.service(),
 
   userInstance: null,
   organizationInstance: null,
@@ -93,7 +92,7 @@ export default Ember.Service.extend({
     if (organization) {
       this.organizationInstance.setUserId(organization.get('id'));
       let organizationEventProperties = Object.assign(
-        {'user_id': this.get('currentUser.id')},
+        {'user_id': this.get('currentUser.user.id')},
         eventProperties
       );
       this.organizationInstance.logEvent(eventName, organizationEventProperties);

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  session: Ember.inject.service(),
+  store: Ember.inject.service(),
+  analytics: Ember.inject.service(),
+
+  user: null,
+
+  load() {
+    if (this.get('session.isAuthenticated')) {
+      return this.get('store').queryRecord('user', {}).then((user) => {
+        this.get('analytics').identifyUser(user);
+        this.set('user', user);
+      });
+    } else {
+      return Ember.RSVP.resolve();
+    }
+  }
+});

--- a/app/session-stores/application.js
+++ b/app/session-stores/application.js
@@ -1,0 +1,4 @@
+// app/session-stores/application.js
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+
+export default CookieStore.extend();

--- a/app/templates/auth/failure.hbs
+++ b/app/templates/auth/failure.hbs
@@ -1,0 +1,1 @@
+<h1>Auth failure</h1>

--- a/app/templates/components/fixed-top-header.hbs
+++ b/app/templates/components/fixed-top-header.hbs
@@ -28,7 +28,7 @@
       </div>
     {{/if}}
     {{#if session.isAuthenticated}}
-      {{nav-menu user=session.data.authenticated.user currentOrganization=currentOrganization}}
+      {{nav-menu user=currentUser.user currentOrganization=currentOrganization}}
     {{else}}
       {{nav-menu}}
     {{/if}}

--- a/app/templates/components/invitation-handler.hbs
+++ b/app/templates/components/invitation-handler.hbs
@@ -12,7 +12,7 @@
       <button class="Button Button--primary" {{action "accept"}}>Accept invitation</button>
     </p>
     <p>
-      Joining as <strong>{{user-name user=currentUser}}</strong>. You can <a href="#" {{action "invalidateSession"}}>logout</a> and login as a different user.
+      Joining as <strong>{{user-name user=currentUser.user}}</strong>. You can <a href="#" {{action "invalidateSession"}}>logout</a> and login as a different user.
     </p>
   {{/if}}
 </div>

--- a/app/templates/components/organizations/github-settings.hbs
+++ b/app/templates/components/organizations/github-settings.hbs
@@ -35,7 +35,7 @@
 
     {{!-- Show special "sync private repos" section if on bot user and the current user is the bot user. --}}
     {{#if (eq changeset.githubAuthMechanism "github-bot-user")}}
-      {{#if (eq organization.githubBotUser session.data.authenticated.user)}}
+      {{#if (eq organization.githubBotUser currentUser.user)}}
         {{sync-repos-section organization=organization}}
       {{/if}}
     {{/if}}

--- a/app/templates/components/organizations/jump-to-billing.hbs
+++ b/app/templates/components/organizations/jump-to-billing.hbs
@@ -9,7 +9,7 @@
     initiallyOpened=true
     close=(action "hide")
     matchTriggerWidth=false
-    options=currentUser.organizations
+    options=currentUser.user.organizations
     onchange=(action "chooseOrganization")
     as |organization|
     }}

--- a/app/templates/components/organizations/switcher-nav.hbs
+++ b/app/templates/components/organizations/switcher-nav.hbs
@@ -20,11 +20,11 @@
     {{#link-to "organizations.new" classNames="Button Button--onDark Button--withLeftIcon"}}
       {{fa-icon "plus-circle fa--left"}} Create new organization
     {{/link-to}}
-    {{#if currentUser.organizations.isPending}}
+    {{#if currentUser.user.organizations.isPending}}
       {{loading-page}}
     {{else}}
       <ul>
-        {{#each currentUser.organizations as |org|}}
+        {{#each currentUser.user.organizations as |org|}}
           <li>
             {{#link-to "organization.index" org.slug classNames="OrganizationsSwitcherNav-item"}}
               {{org.name}}

--- a/app/templates/components/organizations/user-card.hbs
+++ b/app/templates/components/organizations/user-card.hbs
@@ -12,7 +12,8 @@
     {{#if (eq "admin" organizationUser.organization.currentUserMembership.role)}}
       {{!-- Allow admin to do everything. --}}
       {{forms/organization-user-edit organizationUser=organizationUser}}
-    {{else if (eq organizationUser.user.id currentUser.id)}}
+    {{else if (eq organizationUser.user.id currentUser.user.id)}}
+      <h5>second</h5>
       {{!-- Allow member to view their own record. --}}
       {{forms/organization-user-edit organizationUser=organizationUser}}
     {{else}}

--- a/app/templates/components/sync-repos-section.hbs
+++ b/app/templates/components/sync-repos-section.hbs
@@ -17,15 +17,15 @@
   {{sync-repos-button private=true classes="Button--small"}}
   <div class="SyncReposSection-info">
     Last synced public repos:
-    {{#if session.data.authenticated.user.lastSyncedAt}}
-      {{moment-from-now session.data.authenticated.user.lastSyncedAt}}
+    {{#if currentUser.user.lastSyncedAt}}
+      {{moment-from-now currentUser.user.lastSyncedAt}}
     {{else}}
       never
     {{/if}}
     <br>
     Last synced private repos:
-    {{#if session.data.authenticated.user.lastPrivateSyncedAt}}
-      {{moment-from-now session.data.authenticated.user.lastPrivateSyncedAt}}
+    {{#if currentUser.user.lastPrivateSyncedAt}}
+      {{moment-from-now currentUser.user.lastPrivateSyncedAt}}
     {{else}}
       never
     {{/if}}

--- a/app/templates/github-login.hbs
+++ b/app/templates/github-login.hbs
@@ -1,0 +1,6 @@
+Redirecting to github login screen...
+<div id='login-url' data-login-url="{{model.redirectTarget}}"></div>
+<script>
+  var doc = document.getElementById("login-url")
+  window.location.replace(doc.dataset.loginUrl);
+</script>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,6 +1,6 @@
 <div class="container Header Header--large">
   {{#if session.isAuthenticated}}
-    {{nav-menu user=session.data.authenticated.user}}
+    {{nav-menu user=currentUser.user}}
   {{else}}
     {{nav-menu}}
   {{/if}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,6 +6,9 @@ module.exports = function(environment) {
     environment: environment,
     rootURL: '/',
     locationType: 'auto',
+    fastboot: {
+      hostWhitelist: ['percy.io', 'canary.percy.io', /^localhost:\d+$/, /^dev.percy.local:\d+$/]
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -53,10 +56,8 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    if (process.env.PERCY_DEV_MIRAGE === 'yes') {
-      ENV['ember-cli-mirage'] = {
-        enabled: true
-      }
+    ENV['ember-cli-mirage'] = {
+      enabled: (process.env.PERCY_DEV_MIRAGE === 'yes')
     }
     ENV.APP.githubUrls = {
       integration: 'https://github.com/integrations/percy-dev/installations/new',

--- a/fastboot-tests/tutorials-test.js
+++ b/fastboot-tests/tutorials-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+describe('tutorials', function() {
+
+  it('renders', function() {
+    return this.visit('/docs/tutorials/example-apps')
+      .then(function(res) {
+        let $ = res.jQuery;
+        let response = res.response;
+
+        // add your real tests here
+        expect(response.statusCode).to.equal(200);
+        expect($('div.DocsContainer div.DocsBody h1').text()).to.equal('Tutorials');
+      });
+  });
+
+});

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,4 +1,5 @@
 import Mirage from 'ember-cli-mirage';
+import config from '../config/environment';
 
 export default function() {
   this.passthrough('http://api.amplitude.com');
@@ -137,4 +138,7 @@ export default function() {
   this.get('/builds/:id');
   this.get('/builds/:build_id/snapshots');
   this.get('/builds/:build_id/comparisons');
+  if (config.PERCY_WEB_API_HOST) {
+    this.passthrough(config.PERCY_WEB_API_HOST+'/**');
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start-production-for-testing": "ember server --environment=production",
     "build-production": "yarn run clean && ember build --environment=production",
     "test": "ember test",
+    "fastboot:test": "ember fastboot:test",
     "test:server": "ember test --server",
     "test:node_debug": "node debug node_modules/ember-cli/bin/ember test --server"
   },
@@ -33,6 +34,7 @@
     "ember-cli-chai": "^0.4.2",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.0.0",
+    "ember-cli-fastboot": "^1.0.0-rc.4",
     "ember-cli-htmlbars": "^2.0.2",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.6.1",
@@ -46,6 +48,7 @@
     "ember-concurrency": "^0.8.6",
     "ember-data": "2.11.3",
     "ember-export-application-global": "^2.0.0",
+    "ember-fastboot-app-tests": "^0.2.0",
     "ember-font-awesome": "^3.0.5",
     "ember-inflector": "^2.0.1",
     "ember-load-initializers": "^1.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -16,7 +16,6 @@ module.exports = function(app) {
   var morgan  = require('morgan');
   app.use(morgan('dev'));
 
-  mocks.forEach(function(route) { route(app); });
   proxies.forEach(function(route) { route(app); });
 
 };

--- a/tests/acceptance/join-test.js
+++ b/tests/acceptance/join-test.js
@@ -36,8 +36,8 @@ describe('Acceptance: Join', function() {
       expect(currentPath()).to.equal('join');
     });
     percySnapshot(this.test);
-
     click('.InvitationHandler button:contains("Accept invitation")');
+
     andThen(() => {
       expect(currentPath()).to.equal('organization.index');
     });

--- a/tests/helpers/setup-acceptance.js
+++ b/tests/helpers/setup-acceptance.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import startApp from 'percy-web/tests/helpers/start-app';
 import destroyApp from 'percy-web/tests/helpers/destroy-app';
+import {authenticateSession} from 'percy-web/tests/helpers/ember-simple-auth';
 
 // Import mocha helpers so that they will be included for all tests.
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "it|describe" }]*/
@@ -72,6 +73,7 @@ export function setupSession(createData) {
     expect(this.loginUser).not.to.be.undefined; // eslint-disable-line no-unused-expressions
     if (this.loginUser) {
       this.loginUser.update({_currentLoginInTest: true});
+      authenticateSession(this.application, {auth: true});
     }
   });
   afterEach(function() {

--- a/tests/unit/services/analytics-test.js
+++ b/tests/unit/services/analytics-test.js
@@ -5,7 +5,7 @@ import {setupTest} from 'ember-mocha';
 
 describe('AnalyticsService', function() {
   setupTest('service:analytics', {
-    needs: ['service:session', 'service:adminMode']
+    needs: ['service:session', 'service:adminMode', 'service:currentUser']
   });
 
   // Replace this with your real tests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,10 @@
   dependencies:
     "@glimmer/util" "^0.22.3"
 
+abab@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -97,6 +101,12 @@ accepts@1.3.3, accepts@~1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
+  dependencies:
+    acorn "^4.0.4"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -107,7 +117,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.1, acorn@^4.0.3:
+acorn@^4.0.1, acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
@@ -191,6 +201,10 @@ ansi-styles@~1.0.0:
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
+
+any-promise@^1.0.0, any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
 anymatch@^1.3.0:
   version "1.3.0"
@@ -1658,6 +1672,10 @@ browser-resolve@^1.11.0:
   dependencies:
     resolve "1.1.7"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
 browserslist@^2.1.2:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.1.5.tgz#e882550df3d1cd6d481c1a3e0038f2baf13a4711"
@@ -1924,7 +1942,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.5.0, commander@^2.6.0:
+commander@2.9.0, commander@^2.5.0, commander@^2.6.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1966,7 +1984,7 @@ compressible@~2.0.8:
   dependencies:
     mime-db ">= 1.27.0 < 2"
 
-compression@^1.4.4:
+compression@^1.4.4, compression@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.6.2.tgz#cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3"
   dependencies:
@@ -2023,6 +2041,10 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
+content-type-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
+
 content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
@@ -2043,6 +2065,10 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+cookie@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.2.4.tgz#a8c155aa7b9b2cf2c4d32ebc7b9a0aa288ccc6bd"
+
 copy-dereference@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/copy-dereference/-/copy-dereference-1.0.0.tgz#6b131865420fd81b413ba994b44d3655311152b6"
@@ -2059,6 +2085,12 @@ core-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/core-object/-/core-object-1.1.0.tgz#86d63918733cf9da1a5aae729e62c0a88e66ad0a"
 
+core-object@^2.0.5:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/core-object/-/core-object-2.1.1.tgz#4b7a5f1edefcb1e6d0dcb58eab1b9f90bfc666a8"
+  dependencies:
+    chalk "^1.1.3"
+
 core-object@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-object/-/core-object-3.1.3.tgz#df399b3311bdb0c909e8aae8929fc3c1c4b25880"
@@ -2068,6 +2100,15 @@ core-object@^3.0.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cpr@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cpr/-/cpr-2.1.0.tgz#a1b7baaa111cfbe55260772100a0296ec9d4a29d"
+  dependencies:
+    graceful-fs "^4.1.5"
+    minimist "^1.2.0"
+    mkdirp "~0.5.1"
+    rimraf "^2.5.4"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -2093,6 +2134,16 @@ cryptiles@2.x.x:
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
+
+"cssstyle@>= 0.2.37 < 0.3.0":
+  version "0.2.37"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+  dependencies:
+    cssom "0.3.x"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -2124,13 +2175,19 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+  dependencies:
+    ms "0.7.2"
+
 debug@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
   dependencies:
     ms "2.0.0"
 
-debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
+debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.0, debug@^2.6.8, debug@~2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -2228,7 +2285,7 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
-diff@^3.2.0:
+diff@3.2.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -2298,6 +2355,23 @@ ember-changeset@^1.2.3:
   resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-1.3.0.tgz#ae4cb06ae8add4550a46363263cd5958b522b9a6"
   dependencies:
     ember-cli-babel "^5.1.7"
+
+ember-cli-addon-tests@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-addon-tests/-/ember-cli-addon-tests-0.6.3.tgz#be4daba4d34b77c2bc830dedc88c9baa6903243a"
+  dependencies:
+    chalk "^1.1.3"
+    cpr "^2.0.0"
+    debug "^2.2.0"
+    exists-sync "0.0.4"
+    findup-sync "^0.4.3"
+    fs-extra "^2.0.0"
+    fs-promise "^2.0.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.1"
+    rsvp "^3.1.0"
+    symlink-or-copy "^1.1.3"
+    temp "^0.8.3"
 
 ember-cli-app-version@^3.0.0:
   version "3.0.0"
@@ -2390,6 +2464,32 @@ ember-cli-eslint@^4.0.0:
     ember-cli-version-checker "^2.0.0"
     rsvp "^3.2.1"
     walk-sync "^0.3.0"
+
+ember-cli-fastboot@^1.0.0-rc.4:
+  version "1.0.0-rc3"
+  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-1.0.0-rc3.tgz#971179bdb8f53215025dd23b2f18765b63008584"
+  dependencies:
+    broccoli-concat "^3.2.2"
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^1.1.1"
+    broccoli-plugin "^1.2.1"
+    broccoli-stew "^1.2.0"
+    chalk "^1.1.3"
+    compression "^1.6.2"
+    core-object "^2.0.5"
+    debug "^2.2.0"
+    ember-cli-babel "^5.1.7"
+    ember-cli-version-checker "^1.3.1"
+    exists-sync "0.0.4"
+    express "^4.8.5"
+    fastboot "1.0.0-rc.6"
+    fastboot-express-middleware "1.0.0-rc.7"
+    json-stable-stringify "^1.0.1"
+    lodash.defaults "^4.0.1"
+    lodash.uniq "^4.2.0"
+    md5-hex "^1.3.0"
+    rsvp "^3.0.16"
+    silent-error "^1.0.0"
 
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
@@ -2607,7 +2707,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2765,6 +2865,22 @@ ember-factory-for-polyfill@^1.1.0:
   dependencies:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
+
+ember-fastboot-app-tests@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-fastboot-app-tests/-/ember-fastboot-app-tests-0.2.0.tgz#34ba082e0ac0fab93d6d512031d8ca8f1aee4ecb"
+  dependencies:
+    chalk "^1.1.3"
+    core-object "^3.0.0"
+    debug "^2.6.0"
+    ember-cli-addon-tests "^0.6.0"
+    ember-cli-babel "^5.1.7"
+    ember-cli-version-checker "^2.0.0"
+    jquery "^3.1.1"
+    jsdom "^9.10.0"
+    mocha "^3.2.0"
+    request "^2.79.0"
+    rsvp "^3.3.3"
 
 ember-fetch@^1.4.2:
   version "1.6.0"
@@ -3204,9 +3320,20 @@ escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escodegen@^1.6.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
+  dependencies:
+    esprima "^2.7.1"
+    estraverse "^1.9.1"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.2.0"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -3267,7 +3394,7 @@ esprima-fb@~15001.1001.0-dev-harmony-fb:
   version "15001.1001.0-dev-harmony-fb"
   resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
 
-esprima@^2.6.0:
+esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -3287,6 +3414,10 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
+
+estraverse@^1.9.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
 estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
@@ -3375,7 +3506,11 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
-express@^4.10.7, express@^4.12.3:
+express-cluster@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/express-cluster/-/express-cluster-0.0.4.tgz#7aa5c39779bbc7550a30525d02b4c022e40b8798"
+
+express@^4.10.7, express@^4.12.3, express@^4.13.3, express@^4.8.5:
   version "4.15.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
   dependencies:
@@ -3469,11 +3604,35 @@ fast-sourcemap-concat@^1.0.1:
     source-map "^0.4.2"
     source-map-url "^0.3.0"
 
+fastboot-express-middleware@1.0.0-rc.7:
+  version "1.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/fastboot-express-middleware/-/fastboot-express-middleware-1.0.0-rc.7.tgz#285dee01734d40bafe983cefb63e7df0c680f282"
+  dependencies:
+    chalk "^1.1.3"
+    fastboot "^1.0.0-rc.3"
+
 fastboot-filter-initializers@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/fastboot-filter-initializers/-/fastboot-filter-initializers-0.0.2.tgz#67aa9e8b22ca4b0e6a244f2450fd1cc6befa45e7"
   dependencies:
     broccoli-funnel "^1.0.1"
+
+fastboot@1.0.0-rc.6, fastboot@^1.0.0-rc.3:
+  version "1.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-1.0.0-rc.6.tgz#09af88b41d1b31fda96be425c857e34b2323115b"
+  dependencies:
+    chalk "^0.5.1"
+    cookie "^0.2.3"
+    debug "^2.1.0"
+    exists-sync "0.0.3"
+    express "^4.13.3"
+    express-cluster "0.0.4"
+    glob "^4.0.5"
+    minimist "^1.2.0"
+    najax "^1.0.1"
+    rsvp "^3.0.16"
+    simple-dom "^0.3.0"
+    source-map-support "^0.4.0"
 
 faye-websocket@~0.10.0:
   version "0.10.0"
@@ -3554,7 +3713,7 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-findup-sync@^0.4.2:
+findup-sync@^0.4.2, findup-sync@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
   dependencies:
@@ -3671,6 +3830,15 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-promise@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
+  dependencies:
+    any-promise "^1.3.0"
+    fs-extra "^2.0.0"
+    mz "^2.6.0"
+    thenify-all "^1.6.0"
 
 fs-readdir-recursive@^0.1.0:
   version "0.1.2"
@@ -3790,6 +3958,15 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^4.0.5:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^2.0.1"
+    once "^1.3.0"
+
 glob@^5.0.10, glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
@@ -3854,7 +4031,7 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3922,6 +4099,10 @@ has-color@~0.1.0:
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -4002,6 +4183,12 @@ homedir-polyfill@^1.0.0:
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
+
+html-encoding-sniffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+  dependencies:
+    whatwg-encoding "^1.0.1"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -4340,6 +4527,10 @@ jade@0.26.3:
     commander "0.6.1"
     mkdirp "0.3.0"
 
+jquery-deferred@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
+
 jquery@^3.1.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
@@ -4391,6 +4582,30 @@ jscodeshift@^0.3.29:
     recast "^0.12.5"
     temp "^0.8.1"
     write-file-atomic "^1.2.0"
+
+jsdom@^9.10.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
+  dependencies:
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
+    array-equal "^1.0.0"
+    content-type-parser "^1.0.1"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
+    escodegen "^1.6.1"
+    html-encoding-sniffer "^1.0.1"
+    nwmatcher ">= 1.3.9 < 2.0.0"
+    parse5 "^1.5.1"
+    request "^2.79.0"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
+    whatwg-encoding "^1.0.1"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -4564,6 +4779,10 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
 lodash._baseflatten@^3.0.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz#0770ff80131af6e34f3b511796a7ba5214e65ff7"
@@ -4631,13 +4850,21 @@ lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.4.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+
 lodash.debounce@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
   dependencies:
     lodash._getnative "^3.0.0"
 
-lodash.defaults@^4.2.0:
+lodash.defaults@^4.0.1, lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
@@ -4997,7 +5224,7 @@ minimatch@0.3:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^2.0.3:
+minimatch@^2.0.1, minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
@@ -5007,7 +5234,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5015,7 +5242,7 @@ mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5043,6 +5270,22 @@ mocha@^2.5.3:
     mkdirp "0.5.1"
     supports-color "1.2.0"
     to-iso-string "0.0.2"
+
+mocha@^3.2.0:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.2.tgz#d0ef4d332126dbf18d0d640c9b382dd48be97594"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.0"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 moment-timezone@~0.5.11:
   version "0.5.13"
@@ -5091,6 +5334,22 @@ mute-stream@0.0.6:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mz@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.6.0.tgz#c8b8521d958df0a4f2768025db69c719ee4ef1ce"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
+najax@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/najax/-/najax-1.0.3.tgz#11145f4d910446ea661d8ab7fcef53f6ad164ae5"
+  dependencies:
+    jquery-deferred "^0.3.0"
+    lodash.defaultsdeep "^4.6.0"
+    qs "^6.2.0"
 
 nan@^2.3.2:
   version "2.6.2"
@@ -5237,6 +5496,10 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+"nwmatcher@>= 1.3.9 < 2.0.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.0.tgz#b4389362170e7ef9798c3c7716d80ebc0106fccf"
+
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
@@ -5297,7 +5560,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -5386,6 +5649,10 @@ parse-json@^2.2.0:
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
+parse5@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
 parsejson@0.0.3:
   version "0.0.3"
@@ -5565,7 +5832,7 @@ q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@6.4.0, qs@^6.4.0, qs@~6.4.0:
+qs@6.4.0, qs@^6.2.0, qs@^6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
@@ -6000,6 +6267,10 @@ sass-graph@^2.1.1:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
+sax@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -6194,6 +6465,12 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+  dependencies:
+    amdefine ">=0.0.4"
+
 spawn-args@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/spawn-args/-/spawn-args-0.2.0.tgz#fb7d0bd1d70fd4316bd9e3dec389e65f9d6361bb"
@@ -6354,6 +6631,12 @@ supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
 
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
+
 supports-color@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
@@ -6362,7 +6645,11 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
+symbol-tree@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+
+symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.3, symlink-or-copy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz#cabe61e0010c1c023c173b25ee5108b37f4b4aa3"
 
@@ -6394,7 +6681,7 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
-temp@0.8.3, temp@^0.8.1:
+temp@0.8.3, temp@^0.8.1, temp@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
   dependencies:
@@ -6439,6 +6726,18 @@ text-table@~0.2.0:
 "textextensions@1 || 2":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.1.0.tgz#1be0dc2a0dc244d44be8a09af6a85afb93c4dbc3"
+
+thenify-all@^1.0.0, thenify-all@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
 
 through@^2.3.6, through@^2.3.8, through@~2.3.8:
   version "2.3.8"
@@ -6489,11 +6788,15 @@ to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
 
-tough-cookie@>=2.3.0, tough-cookie@~2.3.0:
+tough-cookie@>=2.3.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 tree-sync@^1.2.1, tree-sync@^1.2.2:
   version "1.2.2"
@@ -6693,6 +6996,14 @@ watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+
+webidl-conversions@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
+
 websocket-driver@>=0.5.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.6.5.tgz#5cb2556ceb85f4373c6d8238aa691c8454e13a36"
@@ -6703,9 +7014,22 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
+whatwg-encoding@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
+  dependencies:
+    iconv-lite "0.4.13"
+
 whatwg-fetch@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
+whatwg-url@^4.3.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-module@^1.0.0:
   version "1.0.0"
@@ -6790,6 +7114,10 @@ wtf-8@1.0.0:
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
+xml-name-validator@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
 xmldom@^0.1.19:
   version "0.1.27"


### PR DESCRIPTION
Summary of changes:

- added _FASTBOOT variables to adapter, as in fastboot there is no `http-proxy` so we're routing our requests to api hosts directly.
- `restore` in authenticator does not call user endpoint in api anymore. In non fastboot we do a re-render once the promise returned by `restore` resolves. On fastboot there is no rerender so `restore` should be an immediate thing.
-  `currentUser` is now based on ember-simple-auth's [currentUser patterns](https://github.com/simplabs/ember-simple-auth/blob/master/guides/managing-current-user.md), this is needed as session does not always have user immediately (see on `restore`). This was the biggest change replacing `currentUser: Ember.computed.alias('session.data.authenticated.user')` with `currentUser: Ember.inject.service()` and we also need to use `currentUser.user` instead of just `user`
-  some refactorings in authentication
   - new `github-login` route to initiate redirect to github oauth flow as we cannot use `window.location=...` in case of fastboot
   - new `auth/failure` route to catch failures in auth
   - new `auth/success` route which is called on sucessfull authentication
   - we also redirect save ESA `attemptedTransition` to cookie which is used by ESA at `auth/sucess` to redirect to the url before the auth