### PR TITLE
Remove tendrils of build width selector, PLUS snapshot sort algo tests

### DIFF
--- a/app/components/build-container.js
+++ b/app/components/build-container.js
@@ -1,4 +1,4 @@
-import {max, oneWay, or} from '@ember/object/computed';
+import {or} from '@ember/object/computed';
 import Component from '@ember/component';
 import PollingMixin from 'percy-web/mixins/polling';
 
@@ -11,8 +11,7 @@ export default Component.extend(PollingMixin, {
     'classes',
     'isShowingModal:BuildContainer--snapshotModalOpen:BuildContainer--snapshotModalClosed',
   ],
-  maxWidth: max('build.comparisonWidths'),
-  buildContainerSelectedWidth: oneWay('maxWidth'),
+
   currentPosition: null,
 
   showComparisons: or('build.isPending', 'build.isProcessing', 'build.isFinished'),

--- a/app/components/build-container.js
+++ b/app/components/build-container.js
@@ -36,8 +36,5 @@ export default Component.extend(PollingMixin, {
     showSupport() {
       this.sendAction('showSupport');
     },
-    snapshotWidthChangeTriggered() {
-      this.set('noWidthSelected', true);
-    },
   },
 });

--- a/app/components/comparison-switcher.js
+++ b/app/components/comparison-switcher.js
@@ -3,15 +3,4 @@ import Component from '@ember/component';
 export default Component.extend({
   selectedWidth: null,
   comparisons: [],
-  buildWidths: [],
-
-  actions: {
-    updateSelectedWidth(value) {
-      if (value === parseInt(this.get('selectedWidth'))) {
-        return;
-      }
-
-      this.get('updateSelectedWidth')(value);
-    },
-  },
 });

--- a/app/components/comparison-viewer.js
+++ b/app/components/comparison-viewer.js
@@ -5,9 +5,7 @@ export default Component.extend({
   comparison: null,
 
   classNames: ['ComparisonViewer bg-gray-000 border-bottom border-gray-100'],
-  hasNoWidth: computed('comparison', 'snapshotSelectedWidth', function() {
-    return parseInt(this.get('snapshotSelectedWidth')) !== this.get('comparison.width');
-  }),
+
   showNoDiffSnapshot: false,
   isOverlayEnabled: true,
   comparisonUrl: computed(function() {

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -13,13 +13,12 @@ export default Component.extend({
   'data-test-snapshot-list': true,
 
   activeSnapshotId: null,
-  buildContainerSelectedWidth: null,
   lastSnapshotIndex: null,
   selectedSnapshotIndex: -1,
   snapshotComponents: null,
   updateActiveSnapshotId: null,
 
-  sortedSnapshots: computed('snapshots.[]', 'buildContainerSelectedWidth', function() {
+  sortedSnapshots: computed('snapshots.[]', function() {
     return snapshotSort(this.get('snapshots'));
   }),
 

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -19,7 +19,7 @@ export default Component.extend({
   updateActiveSnapshotId: null,
 
   sortedSnapshots: computed('snapshots.[]', function() {
-    return snapshotSort(this.get('snapshots'));
+    return snapshotSort(this.get('snapshots').toArray());
   }),
 
   hideNoDiffs: computed('noDiffSnapshotsCount', function() {

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -18,8 +18,6 @@ export default Component.extend({
   selectedSnapshotIndex: -1,
   snapshotComponents: null,
   updateActiveSnapshotId: null,
-  updateSelectedWidth: null,
-  snapshots: null,
 
   sortedSnapshots: computed('snapshots.[]', 'buildContainerSelectedWidth', function() {
     let snapshots = this.get('snapshots').toArray();

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -5,6 +5,7 @@ import $ from 'jquery';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 import {inject as service} from '@ember/service';
+import snapshotSort from 'percy-web/lib/snapshot-sort';
 
 export default Component.extend({
   classNames: ['SnapshotList'],
@@ -13,56 +14,15 @@ export default Component.extend({
 
   activeSnapshotId: null,
   buildContainerSelectedWidth: null,
-  buildWidths: [],
   lastSnapshotIndex: null,
   selectedSnapshotIndex: -1,
   snapshotComponents: null,
   updateActiveSnapshotId: null,
 
   sortedSnapshots: computed('snapshots.[]', 'buildContainerSelectedWidth', function() {
-    let snapshots = this.get('snapshots').toArray();
-    let width = parseInt(this.get('buildContainerSelectedWidth'));
-
-    function comparisonAtCurrentWidth(snapshot) {
-      return snapshot.get('comparisons').findBy('width', width);
-    }
-
-    return snapshots.sort(function(a, b) {
-      // Prioritize snapshots with diffs at any widths over snapshots with no diffs at any widths
-      function maxDiffRatioAnyWidth(comparisons) {
-        let comparisonWidths = comparisons.mapBy('smartDiffRatio').filter(x => x);
-        return Math.max(0, ...comparisonWidths); // Provide minimum of one param to avoid -Infinity
-      }
-
-      let maxComparisonDiffA = maxDiffRatioAnyWidth(a.get('comparisons'));
-      let maxComparisonDiffB = maxDiffRatioAnyWidth(b.get('comparisons'));
-      if (maxComparisonDiffA > 0 && maxComparisonDiffB == 0) {
-        // First snapshot has diffs, second doesn't at any widths
-        return -1;
-      } else if (maxComparisonDiffA == 0 && maxComparisonDiffB > 0) {
-        // Second snapshot has diffs, first doesn't at any widths
-        return 1;
-      }
-
-      // Next prioritize snapshots with comparisons at the current width
-      let comparisonForA = comparisonAtCurrentWidth(a);
-      let comparisonForB = comparisonAtCurrentWidth(b);
-      if (comparisonForA && !comparisonForB) {
-        // First snapshot has a comparison at the current width.
-        return -1;
-      } else if (!comparisonForA && comparisonForB) {
-        // Second snapshot has a comparison at the current width.
-        return 1;
-      } else if (comparisonForA && comparisonForB) {
-        // Both snapshots have a comparison for the current width, sort by diff percentage.
-        return comparisonForB.get('smartDiffRatio') - comparisonForA.get('smartDiffRatio');
-      }
-
-      // Finally, sort by diff ratio across all widths.
-      // Sorts descending.
-      return maxComparisonDiffB + maxComparisonDiffA;
-    });
+    return snapshotSort(this.get('snapshots'));
   }),
+
   hideNoDiffs: computed('noDiffSnapshotsCount', function() {
     let noDiffsCount = this.get('noDiffSnapshotsCount');
     let activeSnapshotId = this.get('activeSnapshotId');

--- a/app/components/snapshot-viewer-full.js
+++ b/app/components/snapshot-viewer-full.js
@@ -1,4 +1,4 @@
-import {alias, notEmpty, sort} from '@ember/object/computed';
+import {alias, sort} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 
@@ -33,8 +33,6 @@ export default Component.extend({
     }
     return comparison;
   }),
-
-  hasComparisonAtSelectedWidth: notEmpty('selectedComparison'),
 
   didRender() {
     this._super(...arguments);

--- a/app/components/snapshot-viewer-full.js
+++ b/app/components/snapshot-viewer-full.js
@@ -1,4 +1,4 @@
-import {alias, sort} from '@ember/object/computed';
+import {alias} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 
@@ -20,18 +20,14 @@ export default Component.extend({
   snapshot: computed('build.snapshots.[]', 'snapshotId', function() {
     return this.get('build.snapshots').findBy('id', this.get('snapshotId'));
   }),
-  comparisons: alias('snapshot.comparisons'),
-  comparisonsSortedByWidth: sort('comparisons', 'widthSort'),
-  widthSort: ['width'],
 
-  selectedComparison: computed('comparisons.@each.width', 'snapshotSelectedWidth', function() {
-    let comparisons = this.get('comparisons') || [];
-    let width = parseInt(this.get('snapshotSelectedWidth'), 10);
-    let comparison = comparisons.findBy('width', width);
-    if (!comparisons) {
-      comparison = this.get('comparisonsSortedByWidth.lastObject');
-    }
-    return comparison;
+  comparisons: alias('snapshot.comparisons'),
+
+  selectedComparison: computed('snapshot.widestComparison', 'snapshotSelectedWidth', function() {
+    return (
+      this.get('snapshot').comparisonForWidth(this.get('snapshotSelectedWidth')) ||
+      this.get('snapshot.widestComparison')
+    );
   }),
 
   didRender() {
@@ -44,8 +40,7 @@ export default Component.extend({
 
   actions: {
     updateSelectedWidth(value) {
-      let comparisons = this.get('comparisons') || [];
-      let comparison = comparisons.findBy('width', parseInt(value, 10));
+      let comparison = this.get('snapshot').comparisonForWidth(value);
 
       this.set('selectedComparison', comparison);
       this.set('snapshotSelectedWidth', value);

--- a/app/components/snapshot-viewer-header.js
+++ b/app/components/snapshot-viewer-header.js
@@ -7,7 +7,6 @@ export default Component.extend({
   // required params
   snapshot: null,
   flashMessages: service(),
-  hasComparisonAtSelectedWidth: null,
   selectedWidth: null,
   selectedComparison: null,
 

--- a/app/components/snapshot-viewer-header.js
+++ b/app/components/snapshot-viewer-header.js
@@ -6,7 +6,6 @@ import {alias, equal, filterBy, not, or} from '@ember/object/computed';
 export default Component.extend({
   // required params
   snapshot: null,
-  buildWidths: null,
   flashMessages: service(),
   hasComparisonAtSelectedWidth: null,
   selectedWidth: null,

--- a/app/components/snapshot-viewer.js
+++ b/app/components/snapshot-viewer.js
@@ -1,4 +1,4 @@
-import {not, alias, notEmpty, or, sort} from '@ember/object/computed';
+import {not, alias, or, sort} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 
@@ -13,7 +13,6 @@ export default Component.extend({
   attributeBindings: ['data-test-snapshot-viewer'],
   'data-test-snapshot-viewer': true,
 
-  buildContainerSelectedWidth: null,
   registerChild() {},
   unregisterChild() {},
   selectChild() {},
@@ -72,8 +71,6 @@ export default Component.extend({
     let comparisons = this.get('snapshot.comparisons') || [];
     return comparisons.findBy('width', this.get('snapshotSelectedWidth'));
   }),
-
-  hasComparisonAtSelectedWidth: notEmpty('comparisonForSelectedWidth'),
 
   didInsertElement() {
     this._super(...arguments);

--- a/app/components/snapshot-viewer.js
+++ b/app/components/snapshot-viewer.js
@@ -1,4 +1,4 @@
-import {not, alias, or, sort} from '@ember/object/computed';
+import {not, alias, or} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 
@@ -18,40 +18,18 @@ export default Component.extend({
   selectChild() {},
 
   comparisons: alias('snapshot.comparisons'),
-  comparisonsSortedByWidth: sort('comparisons', 'widthSort'),
-  widthSort: ['width'],
 
   snapshotSelectedWidth: or('userSelectedWidth', 'defaultWidth'),
   userSelectedWidth: null,
 
-  defaultWidth: computed('comparisons.@each.width', 'isExpanded', function() {
-    let width = this.get('comparisonsSortedByWidth')
-      .filterBy('isDifferent')
-      .get('lastObject.width');
+  defaultWidth: or('snapshot.maxComparisonWidthWithDiff', 'snapshot.maxComparisonWidth'),
 
-    if (!width) {
-      width = this.get('comparisonsSortedByWidth').get('lastObject.width');
-    }
-
-    return width;
+  selectedComparison: computed('snapshot.widestComparison', 'snapshotSelectedWidth', function() {
+    return (
+      this.get('snapshot').comparisonForWidth(this.get('snapshotSelectedWidth')) ||
+      this.get('snapshot.widestComparison')
+    );
   }),
-
-  selectedComparison: computed(
-    'comparisons.@each.width',
-    'snapshotSelectedWidth',
-    'comaparisonsSortedByWidth',
-    function() {
-      let width = this.get('snapshotSelectedWidth');
-      let comparisons = this.get('comparisons') || [];
-      let comparison = comparisons.findBy('width', parseInt(width, 10));
-
-      if (!comparison) {
-        comparison = this.get('comparisonsSortedByWidth').get('lastObject');
-      }
-
-      return comparison;
-    },
-  ),
 
   isDefaultExpanded: true,
   isFocus: false,
@@ -66,11 +44,6 @@ export default Component.extend({
   }),
   isNotExpanded: not('isExpanded'),
   isActionable: alias('isNotExpanded'),
-
-  comparisonForSelectedWidth: computed('snapshot.comparisons', 'snapshotSelectedWidth', function() {
-    let comparisons = this.get('snapshot.comparisons') || [];
-    return comparisons.findBy('width', this.get('snapshotSelectedWidth'));
-  }),
 
   didInsertElement() {
     this._super(...arguments);

--- a/app/lib/snapshot-sort.js
+++ b/app/lib/snapshot-sort.js
@@ -1,0 +1,59 @@
+export default function(snapshots) {
+  let width = _maxWidthForSnapshots(snapshots);
+
+  function comparisonAtCurrentWidth(snapshot) {
+    return snapshot.get('comparisons').findBy('width', width);
+  }
+
+  return snapshots.sort(function(a, b) {
+    // Prioritize snapshots with diffs at any widths over snapshots with no diffs at any widths
+    function maxDiffRatioAnyWidth(comparisons) {
+      let comparisonWidths = comparisons.mapBy('smartDiffRatio').filter(x => x);
+      return Math.max(0, ...comparisonWidths); // Provide minimum of one param to avoid -Infinity
+    }
+
+    let maxComparisonDiffA = maxDiffRatioAnyWidth(a.get('comparisons'));
+    let maxComparisonDiffB = maxDiffRatioAnyWidth(b.get('comparisons'));
+    if (maxComparisonDiffA > 0 && maxComparisonDiffB == 0) {
+      // First snapshot has diffs, second doesn't at any widths
+      return -1;
+    } else if (maxComparisonDiffA == 0 && maxComparisonDiffB > 0) {
+      // Second snapshot has diffs, first doesn't at any widths
+      return 1;
+    }
+
+    // Next prioritize snapshots with comparisons at the current width
+    let comparisonForA = comparisonAtCurrentWidth(a);
+    let comparisonForB = comparisonAtCurrentWidth(b);
+    if (comparisonForA && !comparisonForB) {
+      // First snapshot has a comparison at the current width.
+      return -1;
+    } else if (!comparisonForA && comparisonForB) {
+      // Second snapshot has a comparison at the current width.
+      return 1;
+    } else if (comparisonForA && comparisonForB) {
+      // Both snapshots have a comparison for the current width, sort by diff percentage.
+      return comparisonForB.get('smartDiffRatio') - comparisonForA.get('smartDiffRatio');
+    }
+
+    // Finally, sort by diff ratio across all widths.
+    // Sorts descending.
+    return maxComparisonDiffB + maxComparisonDiffA;
+  });
+}
+
+function _maxWidthForSnapshots(snapshots) {
+  // TODO: put `maxComparisonWidth` on snapshot model after snapshots api work is done
+  let maxWidth = snapshots.get('firstObject.comparisons.firstObject.width');
+  snapshots.forEach(snapshot => {
+    let comparisons = snapshot.get('comparisons');
+    comparisons.forEach(comparison => {
+      const tmpWidth = comparison.get('width');
+      if (tmpWidth > maxWidth) {
+        maxWidth = tmpWidth;
+      }
+    });
+  });
+
+  return maxWidth;
+}

--- a/app/lib/snapshot-sort.js
+++ b/app/lib/snapshot-sort.js
@@ -1,35 +1,34 @@
 export default function(snapshots) {
   let width = _maxWidthForSnapshots(snapshots);
 
-  function comparisonAtCurrentWidth(snapshot) {
-    return snapshot.get('comparisons').findBy('width', width);
-  }
-
   return snapshots.sort(function(a, b) {
     // Prioritize snapshots with diffs at any widths over snapshots with no diffs at any widths
-    function maxDiffRatioAnyWidth(comparisons) {
-      let comparisonWidths = comparisons.mapBy('smartDiffRatio').filter(x => x);
-      return Math.max(0, ...comparisonWidths); // Provide minimum of one param to avoid -Infinity
-    }
 
-    let maxComparisonDiffA = maxDiffRatioAnyWidth(a.get('comparisons'));
-    let maxComparisonDiffB = maxDiffRatioAnyWidth(b.get('comparisons'));
-    if (maxComparisonDiffA > 0 && maxComparisonDiffB == 0) {
-      // First snapshot has diffs, second doesn't at any widths
+    let maxDiffRatioA = _maxDiffRatioAnyWidth(a.get('comparisons'));
+    let maxDiffRatioB = _maxDiffRatioAnyWidth(b.get('comparisons'));
+
+    let aHasDiffs = maxDiffRatioA > 0;
+    let bHasDiffs = maxDiffRatioB > 0;
+
+    let aHasNoDiffs = maxDiffRatioA == 0;
+    let bHasNoDiffs = maxDiffRatioB == 0;
+
+    if (aHasDiffs && bHasNoDiffs) {
       return -1;
-    } else if (maxComparisonDiffA == 0 && maxComparisonDiffB > 0) {
-      // Second snapshot has diffs, first doesn't at any widths
+    } else if (bHasDiffs && aHasNoDiffs) {
       return 1;
     }
 
     // Next prioritize snapshots with comparisons at the current width
-    let comparisonForA = comparisonAtCurrentWidth(a);
-    let comparisonForB = comparisonAtCurrentWidth(b);
-    if (comparisonForA && !comparisonForB) {
-      // First snapshot has a comparison at the current width.
+    let comparisonForA = _comparisonAtCurrentWidth(a, width);
+    let comparisonForB = _comparisonAtCurrentWidth(b, width);
+
+    let aHasNoComparisonAtWidth = !comparisonForA;
+    let bHasNoComparisonAtWidth = !comparisonForB;
+
+    if (comparisonForA && bHasNoComparisonAtWidth) {
       return -1;
-    } else if (!comparisonForA && comparisonForB) {
-      // Second snapshot has a comparison at the current width.
+    } else if (comparisonForB && aHasNoComparisonAtWidth) {
       return 1;
     } else if (comparisonForA && comparisonForB) {
       // Both snapshots have a comparison for the current width, sort by diff percentage.
@@ -38,7 +37,7 @@ export default function(snapshots) {
 
     // Finally, sort by diff ratio across all widths.
     // Sorts descending.
-    return maxComparisonDiffB + maxComparisonDiffA;
+    return maxDiffRatioB + maxDiffRatioA;
   });
 }
 
@@ -56,4 +55,13 @@ function _maxWidthForSnapshots(snapshots) {
   });
 
   return maxWidth;
+}
+
+function _comparisonAtCurrentWidth(snapshot, width) {
+  return snapshot.get('comparisons').findBy('width', width);
+}
+
+function _maxDiffRatioAnyWidth(comparisons) {
+  let comparisonWidths = comparisons.mapBy('smartDiffRatio').filter(x => x);
+  return Math.max(0, ...comparisonWidths); // Provide minimum of one param to avoid -Infinity
 }

--- a/app/lib/snapshot-sort.js
+++ b/app/lib/snapshot-sort.js
@@ -42,19 +42,7 @@ export default function(snapshots) {
 }
 
 function _maxWidthForSnapshots(snapshots) {
-  // TODO: put `maxComparisonWidth` on snapshot model after snapshots api work is done
-  let maxWidth = snapshots.get('firstObject.comparisons.firstObject.width');
-  snapshots.forEach(snapshot => {
-    let comparisons = snapshot.get('comparisons');
-    comparisons.forEach(comparison => {
-      const tmpWidth = comparison.get('width');
-      if (tmpWidth > maxWidth) {
-        maxWidth = tmpWidth;
-      }
-    });
-  });
-
-  return maxWidth;
+  return Math.max(...snapshots.mapBy('maxComparisonWidth'));
 }
 
 function _comparisonAtCurrentWidth(snapshot, width) {

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -1,5 +1,5 @@
 import {computed} from '@ember/object';
-import {bool, and, equal, max, not} from '@ember/object/computed';
+import {bool, and, equal, not} from '@ember/object/computed';
 import DS from 'ember-data';
 import moment from 'moment';
 
@@ -108,16 +108,6 @@ export default DS.Model.extend({
     return this.get('snapshots').reduce((acc, snapshot) => {
       return acc.concat(snapshot.get('comparisons').toArray());
     }, []);
-  }),
-
-  comparisonWidths: computed('comparisons.@each.width', function() {
-    let widths = [...new Set(this.get('comparisons').map(c => c.get('width')))];
-    return widths.sort((a, b) => a - b);
-  }),
-
-  defaultSelectedWidth: max('comparisonWidths'),
-  numComparisonWidths: computed('comparisonWidths', function() {
-    return this.get('comparisonWidths').length;
   }),
 
   hasNoDiffs: not('hasDiffs'),

--- a/app/models/snapshot.js
+++ b/app/models/snapshot.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 import {equal} from '@ember/object/computed';
-import {mapBy, max} from '@ember/object/computed';
+import {alias, mapBy, max, sort} from '@ember/object/computed';
+import {computed} from '@ember/object';
 
 export const SNAPSHOT_APPROVED_STATE = 'approved';
 export const SNAPSHOT_UNAPPROVED_STATE = 'unreviewed';
@@ -32,9 +33,24 @@ export default DS.Model.extend({
   //    when compared the baseline.
   reviewStateReason: DS.attr(),
 
-  comparisonWidths: mapBy('comparisons', 'width'),
-  maxComparisonWidth: max('comparisonWidths'),
-
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),
+
+  comparisonWidths: mapBy('comparisons', 'width'),
+  maxComparisonWidth: max('comparisonWidths'),
+  widestComparison: alias('comparisonsSortedByWidth.lastObject'),
+
+  comparisonsSortedByWidth: sort('comparisons', 'widthSort'),
+  widthSort: ['width'],
+
+  maxWidthComparisonWithDiff: computed('comparisonsSortedByWidth.[]', function() {
+    return this.get('comparisonsSortedByWidth')
+      .filterBy('isDifferent')
+      .get('lastObject');
+  }),
+  maxComparisonWidthWithDiff: alias('maxWidthComparisonWidthDiff.width'),
+
+  comparisonForWidth(width) {
+    return this.get('comparisons').findBy('width', parseInt(width, 10));
+  },
 });

--- a/app/models/snapshot.js
+++ b/app/models/snapshot.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import {equal} from '@ember/object/computed';
+import {mapBy, max} from '@ember/object/computed';
 
 export const SNAPSHOT_APPROVED_STATE = 'approved';
 export const SNAPSHOT_UNAPPROVED_STATE = 'unreviewed';
@@ -30,6 +31,9 @@ export default DS.Model.extend({
   // - 'approved' --> 'no_diffs': automatically approved because there were no visual differences
   //    when compared the baseline.
   reviewStateReason: DS.attr(),
+
+  comparisonWidths: mapBy('comparisons', 'width'),
+  maxComparisonWidth: max('comparisonWidths'),
 
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),

--- a/app/templates/components/build-container.hbs
+++ b/app/templates/components/build-container.hbs
@@ -16,8 +16,6 @@
     {{else}}
       {{snapshot-list
         snapshots=snapshots
-        buildContainerSelectedWidth=buildContainerSelectedWidth
-        buildWidths=build.comparisonWidths
         activeSnapshotId=activeSnapshotId
         updateActiveSnapshotId=(action "updateActiveSnapshotId")
         build=build

--- a/app/templates/components/build-container.hbs
+++ b/app/templates/components/build-container.hbs
@@ -20,8 +20,6 @@
         buildWidths=build.comparisonWidths
         activeSnapshotId=activeSnapshotId
         updateActiveSnapshotId=(action "updateActiveSnapshotId")
-        selectedWidth=selectedWidth
-        snapshotWidthChangeTriggered=(action "snapshotWidthChangeTriggered")
         build=build
         showSnapshotFullModalTriggered=(action 'showSnapshotFullModalTriggered')
         isShowingModal=isShowingModal

--- a/app/templates/components/snapshot-list.hbs
+++ b/app/templates/components/snapshot-list.hbs
@@ -12,7 +12,6 @@
     selectChild=(action 'selectChild')
     registerChild=(action 'registerChild')
     unregisterChild=(action 'unregisterChild')
-    snapshotWidthChangeTriggered=snapshotWidthChangeTriggered
     showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
     createReview=createReview
   }}

--- a/app/templates/components/snapshot-list.hbs
+++ b/app/templates/components/snapshot-list.hbs
@@ -7,15 +7,12 @@
 {{#each computedSnapshots as |snapshot index|}}
   {{snapshot-viewer
     snapshot=snapshot
-    buildContainerSelectedWidth=buildContainerSelectedWidth
-    buildWidths=buildWidths
     listIndex=index
     isDefaultExpanded=isDefaultExpanded
     selectChild=(action 'selectChild')
     registerChild=(action 'registerChild')
     unregisterChild=(action 'unregisterChild')
     snapshotWidthChangeTriggered=snapshotWidthChangeTriggered
-    build=build
     showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
     createReview=createReview
   }}

--- a/app/templates/components/snapshot-viewer-full.hbs
+++ b/app/templates/components/snapshot-viewer-full.hbs
@@ -2,7 +2,6 @@
   fullscreen=true
   snapshot=snapshot
   isBuildFinished=build.isFinished
-  buildWidths=buildWidths
   selectedWidth=snapshotSelectedWidth
   selectedComparison=selectedComparison
   hasComparisonAtSelectedWidth=hasComparisonAtSelectedWidth

--- a/app/templates/components/snapshot-viewer-full.hbs
+++ b/app/templates/components/snapshot-viewer-full.hbs
@@ -4,7 +4,6 @@
   isBuildFinished=build.isFinished
   selectedWidth=snapshotSelectedWidth
   selectedComparison=selectedComparison
-  hasComparisonAtSelectedWidth=hasComparisonAtSelectedWidth
   toggleViewMode=(action closeSnapshotFullModal build.id snapshot.id)
   updateSelectedWidth=(action "updateSelectedWidth")
 
@@ -18,7 +17,6 @@
     {{comparison-viewer-full
       comparison=selectedComparison
       comparisonMode=comparisonMode
-      snapshotSelectedWidth=snapshotSelectedWidth
       cycleComparisonMode='cycleComparisonMode'
       data-test-SnapshotViewerFull-comparison-viewer=true
     }}

--- a/app/templates/components/snapshot-viewer-header.hbs
+++ b/app/templates/components/snapshot-viewer-header.hbs
@@ -58,7 +58,6 @@
       <div class="btn-group btn-group-alt">
         {{comparison-switcher
           comparisons=(if isShowingAllComparisons snapshot.comparisons comparisonsWithDiffs)
-          buildWidths=buildWidths
           selectedWidth=selectedWidth
           updateSelectedWidth=updateSelectedWidth
           data-test-SnapshotViewer-widthSwitcher=true

--- a/app/templates/components/snapshot-viewer.hbs
+++ b/app/templates/components/snapshot-viewer.hbs
@@ -4,7 +4,6 @@
   isBuildFinished=build.isFinished
   selectedWidth=snapshotSelectedWidth
   selectedComparison=selectedComparison
-  hasComparisonAtSelectedWidth=hasComparisonAtSelectedWidth
   toggleViewMode=(action showSnapshotFullModalTriggered snapshot.id snapshotSelectedWidth)
   updateSelectedWidth=(action "updateSelectedWidth")
   createReview=(action createReview "approve" build)

--- a/app/templates/components/snapshot-viewer.hbs
+++ b/app/templates/components/snapshot-viewer.hbs
@@ -2,7 +2,6 @@
   fullscreen=false
   snapshot=snapshot
   isBuildFinished=build.isFinished
-  buildWidths=buildWidths
   selectedWidth=snapshotSelectedWidth
   selectedComparison=selectedComparison
   hasComparisonAtSelectedWidth=hasComparisonAtSelectedWidth

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -5,11 +5,6 @@ import sinon from 'sinon';
 import BuildPage from 'percy-web/tests/pages/build-page';
 import {TEST_IMAGE_URLS} from 'percy-web/mirage/factories/screenshot';
 
-// TODO once PR#403 is merged, write tests for approving snapshot, make sure order is correct
-// TODO once PR#403 is merged, write test for being on build page with batched collapsed snapshots,
-// expand batched snapshots, navigate to another build, assert snapshots are correct for that build
-
-// TODO convert this file to use page objects
 describe('Acceptance: Pending Build', function() {
   freezeMoment('2018-05-22');
   setupAcceptance();

--- a/tests/factories/comparison.js
+++ b/tests/factories/comparison.js
@@ -1,7 +1,7 @@
 import FactoryGuy from 'ember-data-factory-guy';
 import moment from 'moment';
 
-export const TEST_BUILD_WIDTHS = [375, 550, 1024];
+export const TEST_COMPARISON_WIDTHS = [375, 550, 1024];
 
 FactoryGuy.define('comparison', {
   default: {

--- a/tests/factories/snapshot.js
+++ b/tests/factories/snapshot.js
@@ -1,7 +1,7 @@
 import FactoryGuy from 'ember-data-factory-guy';
 import {make} from 'ember-data-factory-guy';
 import {SNAPSHOT_APPROVED_STATE, SNAPSHOT_UNAPPROVED_STATE} from 'percy-web/models/snapshot';
-import {TEST_BUILD_WIDTHS} from 'percy-web/tests/factories/comparison';
+import {TEST_COMPARISON_WIDTHS} from 'percy-web/tests/factories/comparison';
 
 FactoryGuy.define('snapshot', {
   default: {
@@ -27,7 +27,7 @@ FactoryGuy.define('snapshot', {
     },
     withComparisons: {
       comparisons: () => {
-        return TEST_BUILD_WIDTHS.map(width => {
+        return TEST_COMPARISON_WIDTHS.map(width => {
           return make('comparison', {width});
         });
       },
@@ -44,7 +44,7 @@ FactoryGuy.define('snapshot', {
 
     new: {
       comparisons: () => {
-        return TEST_BUILD_WIDTHS.map(width => {
+        return TEST_COMPARISON_WIDTHS.map(width => {
           return make('comparison', 'new', {width});
         });
       },

--- a/tests/integration/components/snapshot-list-test.js
+++ b/tests/integration/components/snapshot-list-test.js
@@ -46,7 +46,6 @@ describe('Integration: SnapshotList', function() {
         build=build
         createReview=stub
         updateActiveSnapshotId=stub
-        snapshotWidthChangeTriggered=stub
         showSnapshotFullModalTriggered=stub
       }}`);
 
@@ -82,7 +81,6 @@ describe('Integration: SnapshotList', function() {
         build=build
         createReview=stub
         updateActiveSnapshotId=stub
-        snapshotWidthChangeTriggered=stub
         showSnapshotFullModalTriggered=stub
       }}`);
 
@@ -113,7 +111,6 @@ describe('Integration: SnapshotList', function() {
       build=build
       createReview=stub
       updateActiveSnapshotId=stub
-      snapshotWidthChangeTriggered=stub
       showSnapshotFullModalTriggered=stub
     }}`);
 

--- a/tests/integration/components/snapshot-viewer-full-test.js
+++ b/tests/integration/components/snapshot-viewer-full-test.js
@@ -93,14 +93,6 @@ describe('Integration: SnapshotViewerFull', function() {
       expect(updateComparisonModeStub).to.have.been.calledWith('head');
     });
 
-    it('hides comparison mode controls when no comparison for specified width', function() {
-      // A comparison for this width doesn't exist
-      this.set('snapshotSelectedWidth', 99999);
-
-      expect(FullSnapshotPage.isComparisonModeSwitcherVisible).to.equal(false);
-      percySnapshot(this.test);
-    });
-
     it('shows "New" button when snapshot is new', function() {
       this.set('snapshotId', addedSnapshot.get('id'));
 

--- a/tests/integration/components/snapshot-viewer-full-test.js
+++ b/tests/integration/components/snapshot-viewer-full-test.js
@@ -21,9 +21,6 @@ describe('Integration: SnapshotViewerFull', function() {
   let createReviewStub;
   let addedSnapshot;
   const snapshotTitle = 'Awesome snapshot title';
-  const widthIndex = 1;
-  const buildWidths = TEST_BUILD_WIDTHS;
-  const snapshotSelectedWidth = buildWidths[widthIndex];
 
   beforeEach(function() {
     manualSetup(this.container);
@@ -41,9 +38,13 @@ describe('Integration: SnapshotViewerFull', function() {
     updateComparisonModeStub = sinon.stub();
     createReviewStub = sinon.stub().returns(resolve());
 
+    const snapshotSelectedWidth = snapshots[0]
+      .get('comparisons')
+      .sortBy('width')
+      .get('lastObject.width');
+
     this.setProperties({
       build,
-      buildWidths,
       snapshotSelectedWidth,
       snapshotId: snapshot.get('id'),
       comparisonMode: 'diff',
@@ -56,7 +57,6 @@ describe('Integration: SnapshotViewerFull', function() {
     this.render(hbs`{{snapshot-viewer-full
       snapshotId=snapshotId
       build=build
-      buildWidths=buildWidths
       snapshotSelectedWidth=snapshotSelectedWidth
       comparisonMode=comparisonMode
       transitionRouteToWidth=stub
@@ -117,24 +117,9 @@ describe('Integration: SnapshotViewerFull', function() {
       ).to.equal(true);
     });
 
-    it('has the right number of buttons', function() {
-      expect(
-        FullSnapshotPage.header.widthSwitcher.buttons().count,
-        'there should be correct number of buttons',
-      ).to.equal(buildWidths.length);
-    });
-
-    it('displays the correct text on the buttons', function() {
-      FullSnapshotPage.header.widthSwitcher.buttons().forEach((button, i) => {
-        expect(button.text, `button ${i} should contain correct width`).to.equal(
-          `${buildWidths[i]}px`,
-        );
-      });
-    });
-
     it('displays correct number as selected', function() {
       expect(FullSnapshotPage.header.widthSwitcher.buttons(0).isActive).to.equal(false);
-      expect(FullSnapshotPage.header.widthSwitcher.buttons(widthIndex).isActive).to.equal(true);
+      expect(FullSnapshotPage.header.widthSwitcher.buttons(1).isActive).to.equal(true);
       expect(FullSnapshotPage.header.widthSwitcher.buttons(2).isActive).to.equal(false);
     });
 
@@ -184,10 +169,6 @@ describe('Integration: SnapshotViewerFull with per snapshot approval', function(
   let updateComparisonModeStub;
   let createReviewStub;
   const snapshotTitle = 'Awesome snapshot title';
-  const widthIndex = 1;
-  // NOTE: these need to be the same as the widths in the snapshot factory
-  const buildWidths = [375, 550, 1024];
-  const snapshotSelectedWidth = buildWidths[widthIndex];
 
   beforeEach(function() {
     adminMode.setAdminMode();
@@ -204,6 +185,10 @@ describe('Integration: SnapshotViewerFull with per snapshot approval', function(
     snapshots[0].set('name', snapshotTitle);
     const build = make('build', 'finished');
     build.set('snapshots', snapshots);
+    const snapshotSelectedWidth = snapshots[0]
+      .get('comparisons')
+      .sortBy('width')
+      .get('lastObject.width');
 
     closeSnapshotFullModalStub = sinon.stub();
     updateComparisonModeStub = sinon.stub();
@@ -211,7 +196,6 @@ describe('Integration: SnapshotViewerFull with per snapshot approval', function(
 
     this.setProperties({
       build,
-      buildWidths,
       snapshotSelectedWidth,
       snapshotId: build.get('snapshots.firstObject.id'),
       comparisonMode: 'diff',
@@ -224,7 +208,6 @@ describe('Integration: SnapshotViewerFull with per snapshot approval', function(
     this.render(hbs`{{snapshot-viewer-full
       snapshotId=snapshotId
       build=build
-      buildWidths=buildWidths
       snapshotSelectedWidth=snapshotSelectedWidth
       comparisonMode=comparisonMode
       transitionRouteToWidth=stub

--- a/tests/integration/components/snapshot-viewer-full-test.js
+++ b/tests/integration/components/snapshot-viewer-full-test.js
@@ -9,7 +9,6 @@ import sinon from 'sinon';
 import {resolve} from 'rsvp';
 import adminMode from 'percy-web/lib/admin-mode';
 import FullSnapshotPage from 'percy-web/tests/pages/components/snapshot-viewer-full';
-import {TEST_BUILD_WIDTHS} from 'percy-web/tests/factories/comparison';
 
 describe('Integration: SnapshotViewerFull', function() {
   setupComponentTest('snapshot-viewer-full', {
@@ -38,10 +37,11 @@ describe('Integration: SnapshotViewerFull', function() {
     updateComparisonModeStub = sinon.stub();
     createReviewStub = sinon.stub().returns(resolve());
 
-    const snapshotSelectedWidth = snapshots[0]
+    const snapshotSelectedWidth = snapshot
       .get('comparisons')
       .sortBy('width')
-      .get('lastObject.width');
+      .objectAt(1)
+      .get('width');
 
     this.setProperties({
       build,

--- a/tests/integration/components/snapshot-viewer-test.js
+++ b/tests/integration/components/snapshot-viewer-test.js
@@ -52,7 +52,6 @@ describe('Integration: SnapshotViewer', function() {
       snapshot=snapshot
       build=build
       showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-      snapshotWidthChangeTriggered=stub
       userSelectedWidth=userSelectedWidth
       createReview=createReview
     }}`);
@@ -69,7 +68,6 @@ describe('Integration: SnapshotViewer', function() {
       snapshot=snapshot
       build=build
       showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-      snapshotWidthChangeTriggered=stub
       userSelectedWidth=userSelectedWidth
       createReview=createReview
     }}`);
@@ -83,7 +81,6 @@ describe('Integration: SnapshotViewer', function() {
         snapshot=snapshot
         build=build
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-        snapshotWidthChangeTriggered=stub
         userSelectedWidth=userSelectedWidth
         createReview=createReview
       }}`);
@@ -103,7 +100,6 @@ describe('Integration: SnapshotViewer', function() {
         snapshot=snapshot
         build=build
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-        snapshotWidthChangeTriggered=stub
         userSelectedWidth=userSelectedWidth
         createReview=createReview
       }}`);
@@ -121,7 +117,6 @@ describe('Integration: SnapshotViewer', function() {
         snapshot=snapshot
         build=build
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-        snapshotWidthChangeTriggered=stub
         userSelectedWidth=userSelectedWidth
         createReview=createReview
       }}`);
@@ -136,7 +131,6 @@ describe('Integration: SnapshotViewer', function() {
         snapshot=snapshot
         build=build
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-        snapshotWidthChangeTriggered=stub
         userSelectedWidth=userSelectedWidth
         createReview=createReview
       }}`);
@@ -164,7 +158,6 @@ describe('Integration: SnapshotViewer', function() {
         snapshot=snapshot
         build=build
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-        snapshotWidthChangeTriggered=stub
         userSelectedWidth=userSelectedWidth
         createReview=createReview
       }}`);
@@ -192,7 +185,6 @@ describe('Integration: SnapshotViewer', function() {
         snapshot=snapshot
         build=build
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-        snapshotWidthChangeTriggered=stub
         userSelectedWidth=userSelectedWidth
         createReview=createReview
       }}`);
@@ -266,7 +258,6 @@ describe('Integration: SnapshotViewer with per snapshot approval', function() {
       snapshot=snapshot
       build=build
       showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
-      snapshotWidthChangeTriggered=stub
       createReview=createReview
     }}`);
   });

--- a/tests/integration/components/snapshot-viewer-test.js
+++ b/tests/integration/components/snapshot-viewer-test.js
@@ -232,10 +232,6 @@ describe('Integration: SnapshotViewer with per snapshot approval', function() {
   });
 
   let snapshotTitle;
-  const widthIndex = 1;
-  // NOTE: these need to be the same as the widths in the snapshot factory
-  const buildWidths = [375, 550, 1024];
-  const buildContainerSelectedWidth = buildWidths[widthIndex];
   let showSnapshotFullModalTriggeredStub;
   let createReviewStub;
 
@@ -262,8 +258,6 @@ describe('Integration: SnapshotViewer with per snapshot approval', function() {
       stub,
       snapshot,
       build,
-      buildWidths,
-      buildContainerSelectedWidth,
       showSnapshotFullModalTriggered: showSnapshotFullModalTriggeredStub,
       createReview: createReviewStub,
     });
@@ -271,8 +265,6 @@ describe('Integration: SnapshotViewer with per snapshot approval', function() {
     this.render(hbs`{{snapshot-viewer
       snapshot=snapshot
       build=build
-      buildWidths=buildWidths
-      buildContainerSelectedWidth=buildContainerSelectedWidth
       showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
       snapshotWidthChangeTriggered=stub
       createReview=createReview

--- a/tests/unit/lib/snapshot-sort-test.js
+++ b/tests/unit/lib/snapshot-sort-test.js
@@ -1,0 +1,55 @@
+import {expect} from 'chai';
+import {describe, beforeEach, it} from 'mocha';
+import snapshotSort from 'percy-web/lib/snapshot-sort';
+import Object from '@ember/object';
+
+describe('snapshot-sort', function() {
+  const wideWidth = 800;
+  const narrowWidth = 400;
+
+  const highDiffRatio = 0.99;
+  const lowDiffRatio = 0.25;
+  const noDiffRatio = 0.0;
+
+  let wideComparisonWithHighDiff;
+  let narrowComparisonWithHighDiff;
+  let wideComparisonWithLowDiff;
+  let wideComparisonWithNoDiff;
+
+  beforeEach(() => {
+    wideComparisonWithHighDiff = Object.create({width: wideWidth, smartDiffRatio: highDiffRatio});
+    narrowComparisonWithHighDiff = Object.create({
+      width: narrowWidth,
+      smartDiffRatio: highDiffRatio,
+    });
+    wideComparisonWithLowDiff = Object.create({width: wideWidth, smartDiffRatio: lowDiffRatio});
+    wideComparisonWithNoDiff = Object.create({width: wideWidth, smartDiffRatio: noDiffRatio});
+  });
+
+  it('returns snapshots with diffs before snapshots with no diffs', function() {
+    const snapshotWithDiffs = Object.create({comparisons: [wideComparisonWithLowDiff]});
+    const snapshotWithNoDiffs = Object.create({comparisons: [wideComparisonWithNoDiff]});
+    const unorderedSnapshots = [snapshotWithNoDiffs, snapshotWithDiffs];
+
+    expect(snapshotSort(unorderedSnapshots)).to.eql([snapshotWithDiffs, snapshotWithNoDiffs]);
+  });
+
+  it('returns snapshots with diffs at widest widths before snapshots with no diffs at widest width', function() { // eslint-disable-line
+    const snapshotWithWideDiff = Object.create({comparisons: [wideComparisonWithHighDiff]});
+    const snapshotWithNarrowDiff = Object.create({comparisons: [narrowComparisonWithHighDiff]});
+    const unorderedSnapshots = [snapshotWithNarrowDiff, snapshotWithWideDiff];
+
+    expect(snapshotSort(unorderedSnapshots)).to.eql([snapshotWithWideDiff, snapshotWithNarrowDiff]);
+  });
+
+  it('returns snapshots with high diff ratio before snapshots with low diff ratio', function() {
+    const snapshotWithHighDiffRatio = Object.create({comparisons: [wideComparisonWithHighDiff]});
+    const snapshotWithLowDiffRatio = Object.create({comparisons: [wideComparisonWithLowDiff]});
+    const unorderedSnapshots = [snapshotWithLowDiffRatio, snapshotWithHighDiffRatio];
+
+    expect(snapshotSort(unorderedSnapshots)).to.eql([
+      snapshotWithHighDiffRatio,
+      snapshotWithLowDiffRatio,
+    ]);
+  });
+});

--- a/tests/unit/lib/snapshot-sort-test.js
+++ b/tests/unit/lib/snapshot-sort-test.js
@@ -35,16 +35,28 @@ describe('snapshot-sort', function() {
   });
 
   it('returns snapshots with diffs at widest widths before snapshots with no diffs at widest width', function() { // eslint-disable-line
-    const snapshotWithWideDiff = Object.create({comparisons: [wideComparisonWithHighDiff]});
-    const snapshotWithNarrowDiff = Object.create({comparisons: [narrowComparisonWithHighDiff]});
+    const snapshotWithWideDiff = Object.create({
+      maxComparisonWidth: wideWidth,
+      comparisons: [wideComparisonWithHighDiff],
+    });
+    const snapshotWithNarrowDiff = Object.create({
+      maxComparisonWidth: narrowWidth,
+      comparisons: [narrowComparisonWithHighDiff],
+    });
     const unorderedSnapshots = [snapshotWithNarrowDiff, snapshotWithWideDiff];
 
     expect(snapshotSort(unorderedSnapshots)).to.eql([snapshotWithWideDiff, snapshotWithNarrowDiff]);
   });
 
   it('returns snapshots with high diff ratio before snapshots with low diff ratio', function() {
-    const snapshotWithHighDiffRatio = Object.create({comparisons: [wideComparisonWithHighDiff]});
-    const snapshotWithLowDiffRatio = Object.create({comparisons: [wideComparisonWithLowDiff]});
+    const snapshotWithHighDiffRatio = Object.create({
+      maxComparisonWidth: wideWidth,
+      comparisons: [wideComparisonWithHighDiff],
+    });
+    const snapshotWithLowDiffRatio = Object.create({
+      maxComparisonWidth: wideWidth,
+      comparisons: [wideComparisonWithLowDiff],
+    });
     const unorderedSnapshots = [snapshotWithLowDiffRatio, snapshotWithHighDiffRatio];
 
     expect(snapshotSort(unorderedSnapshots)).to.eql([


### PR DESCRIPTION
This PR removes the remaining tendrils of the build width selector, slightly refactors the snapshot sort method, and finally adds some TESTS for the snapshot sort method, which is very exciting.
It is also on top of the comparison -> snapshot model refactor, so some nice things could happen with the snapshot model.

This PR should be the death of the `comparisonWidths` property on the build model which will simplify a bunch of stuff going forward.