### PR TITLE
Upgrade ember-cli-mocha to 0.15.0 which breaks acceptance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.7.0",
     "ember-cli-mirage": "0.3.3",
-    "ember-cli-mocha": "^0.14.4",
+    "ember-cli-mocha": "^0.15.0",
     "ember-cli-moment-shim": "^3.4.0",
     "ember-cli-page-object": "^1.14.0",
     "ember-cli-sass": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ember/test-helpers@^0.7.16":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.18.tgz#a0c474c3029588ec46d2e406252fc072b7f9aa3c"
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.10.0"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
@@ -2348,6 +2356,12 @@ common-tags@^1.4.0:
   dependencies:
     babel-runtime "^6.18.0"
 
+common-tags@^1.5.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
+  dependencies:
+    babel-runtime "^6.26.0"
+
 commoner@^0.10.1, commoner@~0.10.3:
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
@@ -3062,7 +3076,7 @@ ember-cli-head@^0.4.0:
     ember-cli-babel "^6.1.0"
     ember-cli-htmlbars "^2.0.1"
 
-ember-cli-htmlbars-inline-precompile@^1.0.2:
+ember-cli-htmlbars-inline-precompile@^1.0.0, ember-cli-htmlbars-inline-precompile@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz#5b544f664d5d9911f08cd979c5f70d8cb0ca2add"
   dependencies:
@@ -3152,17 +3166,11 @@ ember-cli-mirage@0.3.3:
     pretender "^1.4.2"
     route-recognizer "^0.2.3"
 
-ember-cli-mocha@^0.14.4:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-mocha/-/ember-cli-mocha-0.14.4.tgz#5f63907f952ec6d6609d551ce321dc83823ba63f"
+ember-cli-mocha@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-mocha/-/ember-cli-mocha-0.15.0.tgz#483b25a2c631b2b1913344686f497a81ced669b6"
   dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0"
-    ember-cli-test-loader "^2.0.0"
-    ember-mocha "^0.12.0"
-    mocha "^2.5.3"
-    resolve "^1.1.7"
+    ember-mocha "^0.13.0"
 
 ember-cli-moment-shim@^3.4.0:
   version "3.5.0"
@@ -3286,7 +3294,7 @@ ember-cli-test-info@^1.0.0:
   dependencies:
     ember-cli-string-utils "^1.0.0"
 
-ember-cli-test-loader@^2.0.0:
+ember-cli-test-loader@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
   dependencies:
@@ -3633,11 +3641,17 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-mocha@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/ember-mocha/-/ember-mocha-0.12.0.tgz#ea27ae9838c8c6e28ea72c48084586ef5fa00a7a"
+ember-mocha@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/ember-mocha/-/ember-mocha-0.13.1.tgz#6c42d76fc7e5579a1ca8499621317b6cde7b4381"
   dependencies:
-    ember-test-helpers "^0.6.3"
+    "@ember/test-helpers" "^0.7.16"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    common-tags "^1.5.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-test-loader "^2.2.0"
+    mocha "^2.5.3"
 
 ember-modal-dialog@^2.4.0:
   version "2.4.1"
@@ -3834,10 +3848,6 @@ ember-source@~2.16.0:
     inflection "^1.12.0"
     jquery "^3.2.1"
     resolve "^1.3.3"
-
-ember-test-helpers@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
 ember-test-selectors@^0.3.8:
   version "0.3.8"


### PR DESCRIPTION
# Do not merge


These test failures are legitimate and the upgrade breaks all of our tests that require logging in. It breaks between ember-cli-mocha v0.14.5 and v0.15.0-beta.1
https://github.com/ember-cli/ember-cli-mocha/blob/master/CHANGELOG.md

The symptom is that whenever it runs a test requiring authentication, it redirects the test to the homepage (dev.percy.local:422) which breaks the test flow so the test will time out.

The `authenticateSession` method in `setup-acceptance` gets called but does not correctly authenticate the session, causing the `else` block in `loadCurrentUser` method in our session service to be hit, which redirects to root.

The `ember-cli-mocha` functions used in our tests are from `ember-simple-auth-auth0` which still uses an old version (0.14.4) of `ember-cli-mocha`.