### PR TITLE
[WIP] Allow users to click "Back" from full screen snapshot

### DIFF
--- a/app/components/build-container.js
+++ b/app/components/build-container.js
@@ -6,10 +6,6 @@ import {inject as service} from '@ember/service';
 export default Component.extend(PollingMixin, {
   build: null,
   classNames: ['BuildContainer'],
-  classNameBindings: [
-    'classes',
-    'isShowingModal:BuildContainer--snapshotModalOpen:BuildContainer--snapshotModalClosed',
-  ],
 
   snapshotQuery: service(),
   snapshotsChanged: null,

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -43,14 +43,12 @@ export default Component.extend({
     $(document).bind(
       'keydown.snapshots',
       function(e) {
-        if (!this.get('isShowingModal')) {
-          if (e.keyCode === 40) {
-            // down arrow
-            this.set('activeSnapshotId', this._calculateNewActiveSnapshotId({isNext: true}));
-          } else if (e.keyCode === 38) {
-            // up arrow
-            this.set('activeSnapshotId', this._calculateNewActiveSnapshotId({isNext: false}));
-          }
+        if (e.keyCode === 40) {
+          // down arrow
+          this.set('activeSnapshotId', this._calculateNewActiveSnapshotId({isNext: true}));
+        } else if (e.keyCode === 38) {
+          // up arrow
+          this.set('activeSnapshotId', this._calculateNewActiveSnapshotId({isNext: false}));
         }
       }.bind(this),
     );

--- a/app/components/snapshot-viewer-full.js
+++ b/app/components/snapshot-viewer-full.js
@@ -6,7 +6,7 @@ export default Component.extend({
   classNames: ['SnapshotViewerFull'],
   build: null,
   comparisonMode: null,
-  snapshotId: null,
+  snapshot: null,
   snapshotSelectedWidth: null,
 
   galleryMap: ['base', 'diff', 'head'],
@@ -15,10 +15,6 @@ export default Component.extend({
 
   galleryIndex: computed('comparisonMode', function() {
     return this.get('galleryMap').indexOf(this.get('comparisonMode'));
-  }),
-
-  snapshot: computed('build.snapshots.[]', 'snapshotId', function() {
-    return this.get('build.snapshots').findBy('id', this.get('snapshotId'));
   }),
 
   comparisons: alias('snapshot.comparisons'),

--- a/app/controllers/organization/project/builds/build.js
+++ b/app/controllers/organization/project/builds/build.js
@@ -1,3 +1,0 @@
-import Controller from '@ember/controller';
-
-export default Controller.extend();

--- a/app/controllers/organization/project/builds/build.js
+++ b/app/controllers/organization/project/builds/build.js
@@ -1,41 +1,4 @@
 import Controller from '@ember/controller';
-import snapshotSort from 'percy-web/lib/snapshot-sort';
-import {filterBy, alias} from '@ember/object/computed';
-import {computed} from '@ember/object';
 
 export default Controller.extend({
-  // set by initializeSnapshotOrdering
-  snapshots: null,
-  sortedSnapshots: computed('snapshots.[]', function() {
-    if (!this.get('snapshots')) {
-      return [];
-    }
-    return snapshotSort(this.get('snapshots').toArray());
-  }),
-  snapshotsUnreviewed: filterBy('sortedSnapshots', 'isUnreviewed', true),
-  snapshotsApproved: filterBy('sortedSnapshots', 'isApprovedByUserEver', true),
-
-  snapshotsChanged: null, // Manually managed by initializeSnapshotOrdering.
-
-  numSnapshotsMissing: 0,
-  numSnapshotsUnchanged: alias('numSnapshotsMissing'),
-
-  // This breaks the binding for snapshotsChanged, specifically so that when a user clicks
-  // approve, the snapshot stays in place until reload.
-  //
-  // Called by the route when entered and snapshots load.
-  // Called by polling when snapshots reload after build is finished.
-  initializeSnapshotOrdering(snapshots) {
-    this.set('snapshots', snapshots);
-    let orderedSnapshots = [].concat(
-      this.get('snapshotsUnreviewed'),
-      this.get('snapshotsApproved'),
-    );
-    this.set('snapshotsChanged', orderedSnapshots);
-
-    const numSnapshotsMissing = this.get('model.totalSnapshots') - snapshots.get('length');
-    this.set('numSnapshotsMissing', numSnapshotsMissing);
-
-    this.set('isSnapshotsLoading', false);
-  },
 });

--- a/app/controllers/organization/project/builds/build.js
+++ b/app/controllers/organization/project/builds/build.js
@@ -1,4 +1,3 @@
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-});
+export default Controller.extend();

--- a/app/controllers/organization/project/builds/build/index.js
+++ b/app/controllers/organization/project/builds/build/index.js
@@ -1,0 +1,49 @@
+import Controller from '@ember/controller';
+import snapshotSort from 'percy-web/lib/snapshot-sort';
+import {filterBy, alias} from '@ember/object/computed';
+import {computed} from '@ember/object';
+
+export default Controller.extend({
+  // set by initializeSnapshotOrdering
+  snapshots: null,
+  sortedSnapshots: computed('snapshots.[]', function() {
+    if (!this.get('snapshots')) {
+      return [];
+    }
+    return snapshotSort(this.get('snapshots').toArray());
+  }),
+  snapshotsUnreviewed: filterBy('sortedSnapshots', 'isUnreviewed', true),
+  snapshotsApproved: filterBy('sortedSnapshots', 'isApprovedByUserEver', true),
+
+  snapshotsChanged: null, // Manually managed by initializeSnapshotOrdering.
+  snapshotsUnchanged: filterBy('sortedSnapshots', 'isUnchanged', true),
+  numSnapshotsMissing: 0,
+  numSnapshotsUnchanged: alias('numSnapshotsMissing'),
+
+  showDiffs: true,
+
+  actions: {
+    toggleShowDiffs() {
+      this.toggleProperty('showDiffs');
+    },
+  },
+
+  // This breaks the binding for snapshotsChanged, specifically so that when a user clicks
+  // approve, the snapshot stays in place until reload.
+  //
+  // Called by the route when entered and snapshots load.
+  // Called by polling when snapshots reload after build is finished.
+  initializeSnapshotOrdering(snapshots) {
+    this.set('snapshots', snapshots);
+    let orderedSnapshots = [].concat(
+      this.get('snapshotsUnreviewed'),
+      this.get('snapshotsApproved'),
+    );
+    this.set('snapshotsChanged', orderedSnapshots);
+
+    const numSnapshotsMissing = this.get('model.totalSnapshots') - snapshots.get('length');
+    this.set('numSnapshotsMissing', numSnapshotsMissing);
+
+    this.set('isSnapshotsLoading', false);
+  },
+});

--- a/app/controllers/organization/project/builds/build/index.js
+++ b/app/controllers/organization/project/builds/build/index.js
@@ -20,14 +20,6 @@ export default Controller.extend({
   numSnapshotsMissing: 0,
   numSnapshotsUnchanged: alias('numSnapshotsMissing'),
 
-  showDiffs: true,
-
-  actions: {
-    toggleShowDiffs() {
-      this.toggleProperty('showDiffs');
-    },
-  },
-
   // This breaks the binding for snapshotsChanged, specifically so that when a user clicks
   // approve, the snapshot stays in place until reload.
   //

--- a/app/routes/organization/project/builds/build.js
+++ b/app/routes/organization/project/builds/build.js
@@ -5,4 +5,18 @@ export default Route.extend(AuthenticatedRouteMixin, {
   model(params) {
     return this.store.findRecord('build', params.build_id);
   },
+
+  actions: {
+    createReview(action, build, snapshots) {
+      const review = this.get('store').createRecord('review', {
+        build: build,
+        snapshots: snapshots,
+      });
+      return review.save().then(() => {
+        const build = this.modelFor(this.routeName);
+        build.get('snapshots').reload();
+        build.reload();
+      });
+    },
+  },
 });

--- a/app/routes/organization/project/builds/build.js
+++ b/app/routes/organization/project/builds/build.js
@@ -1,89 +1,8 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import {inject as service} from '@ember/service';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  snapshotQuery: service(),
   model(params) {
     return this.store.findRecord('build', params.build_id);
-  },
-  afterModel(model) {
-    if (model.get('isFinished')) {
-      let controller = this.controllerFor('organization.project.builds.build');
-      controller.set('isSnapshotsLoading', true);
-
-      this.get('snapshotQuery')
-        .getChangedSnapshots(model)
-        .then(snapshots => {
-          return this._initializeSnapshotOrdering(snapshots);
-        });
-    }
-  },
-
-  _initializeSnapshotOrdering(snapshots) {
-    // this route path needs to be explicit so it will work with fullscreen snapshots.
-    let controller = this.controllerFor('organization.project.builds.build');
-    controller.initializeSnapshotOrdering(snapshots);
-  },
-
-  actions: {
-    initializeSnapshotOrdering(snapshots) {
-      this._initializeSnapshotOrdering(snapshots);
-    },
-    didTransition() {
-      this._super.apply(this, arguments);
-
-      let build = this.modelFor(this.routeName);
-
-      let organization = build.get('project.organization');
-      let eventProperties = {
-        project_id: build.get('project.id'),
-        project_slug: build.get('project.slug'),
-        build_id: build.get('id'),
-        state: build.get('state'),
-      };
-      this.analytics.track('Build Viewed', organization, eventProperties);
-    },
-
-    updateModalState(state) {
-      this.get('currentModel').set('isShowingModal', state);
-    },
-    openSnapshotFullModal(snapshotId, snapshotSelectedWidth) {
-      let build = this.modelFor(this.routeName);
-      let organization = build.get('project.organization');
-      let eventProperties = {
-        project_id: build.get('project.id'),
-        project_slug: build.get('project.slug'),
-        build_id: build.get('id'),
-        snapshot_id: snapshotId,
-      };
-      this.analytics.track('Snapshot Fullscreen Selected', organization, eventProperties);
-
-      this.send('updateModalState', true);
-      this.transitionTo(
-        'organization.project.builds.build.snapshot',
-        snapshotId,
-        snapshotSelectedWidth,
-        {
-          queryParams: {mode: 'diff'},
-        },
-      );
-    },
-    closeSnapshotFullModal(buildId) {
-      this.send('updateModalState', false);
-      this.transitionTo('organization.project.builds.build', buildId);
-    },
-
-    createReview(action, build, snapshots) {
-      const review = this.get('store').createRecord('review', {
-        build: build,
-        snapshots: snapshots,
-      });
-      return review.save().then(() => {
-        const build = this.modelFor(this.routeName);
-        build.get('snapshots').reload();
-        build.reload();
-      });
-    },
   },
 });

--- a/app/routes/organization/project/builds/build/index.js
+++ b/app/routes/organization/project/builds/build/index.js
@@ -49,9 +49,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
       this.analytics.track('Build Viewed', organization, eventProperties);
     },
 
-    // updateModalState(state) {
-    //   this.get('currentModel').set('isShowingModal', state);
-    // },
     openSnapshotFullModal(snapshotId, snapshotSelectedWidth) {
       let build = this.modelFor(this.routeName);
       let organization = build.get('project.organization');

--- a/app/routes/organization/project/builds/build/index.js
+++ b/app/routes/organization/project/builds/build/index.js
@@ -20,10 +20,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }
   },
 
-  resetController(controller) {
-    controller.set('showDiffs', true);
-  },
-
   _initializeSnapshotOrdering(snapshots) {
     // this route path needs to be explicit so it will work with fullscreen snapshots.
     let controller = this.controllerFor('organization.project.builds.build.index');
@@ -60,7 +56,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
       };
       this.analytics.track('Snapshot Fullscreen Selected', organization, eventProperties);
 
-      // this.send('updateModalState', true);
       this.transitionTo(
         'organization.project.builds.build.snapshot',
         snapshotId,

--- a/app/routes/organization/project/builds/build/index.js
+++ b/app/routes/organization/project/builds/build/index.js
@@ -73,21 +73,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
         },
       );
     },
-    closeSnapshotFullModal(buildId) {
-      // this.send('updateModalState', false);
-      this.transitionTo('organization.project.builds.build', buildId);
-    },
-
-    createReview(action, build, snapshots) {
-      const review = this.get('store').createRecord('review', {
-        build: build,
-        snapshots: snapshots,
-      });
-      return review.save().then(() => {
-        const build = this.modelFor(this.routeName);
-        build.get('snapshots').reload();
-        build.reload();
-      });
-    },
   },
 });

--- a/app/routes/organization/project/builds/build/index.js
+++ b/app/routes/organization/project/builds/build/index.js
@@ -1,0 +1,93 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import {inject as service} from '@ember/service';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  snapshotQuery: service(),
+  model() {
+    return this.modelFor('organization.project.builds.build');
+  },
+  afterModel(model) {
+    if (model.get('isFinished')) {
+      let controller = this.controllerFor('organization.project.builds.build.index');
+      controller.set('isSnapshotsLoading', true);
+
+      this.get('snapshotQuery')
+        .getChangedSnapshots(model)
+        .then(snapshots => {
+          return this._initializeSnapshotOrdering(snapshots);
+        });
+    }
+  },
+
+  resetController(controller) {
+    controller.set('showDiffs', true);
+  },
+
+  _initializeSnapshotOrdering(snapshots) {
+    // this route path needs to be explicit so it will work with fullscreen snapshots.
+    let controller = this.controllerFor('organization.project.builds.build.index');
+    controller.initializeSnapshotOrdering(snapshots);
+  },
+
+  actions: {
+    initializeSnapshotOrdering(snapshots) {
+      this._initializeSnapshotOrdering(snapshots);
+    },
+    didTransition() {
+      this._super.apply(this, arguments);
+
+      let build = this.modelFor(this.routeName);
+
+      let organization = build.get('project.organization');
+      let eventProperties = {
+        project_id: build.get('project.id'),
+        project_slug: build.get('project.slug'),
+        build_id: build.get('id'),
+        state: build.get('state'),
+      };
+      this.analytics.track('Build Viewed', organization, eventProperties);
+    },
+
+    // updateModalState(state) {
+    //   this.get('currentModel').set('isShowingModal', state);
+    // },
+    openSnapshotFullModal(snapshotId, snapshotSelectedWidth) {
+      let build = this.modelFor(this.routeName);
+      let organization = build.get('project.organization');
+      let eventProperties = {
+        project_id: build.get('project.id'),
+        project_slug: build.get('project.slug'),
+        build_id: build.get('id'),
+        snapshot_id: snapshotId,
+      };
+      this.analytics.track('Snapshot Fullscreen Selected', organization, eventProperties);
+
+      // this.send('updateModalState', true);
+      this.transitionTo(
+        'organization.project.builds.build.snapshot',
+        snapshotId,
+        snapshotSelectedWidth,
+        {
+          queryParams: {mode: 'diff'},
+        },
+      );
+    },
+    closeSnapshotFullModal(buildId) {
+      // this.send('updateModalState', false);
+      this.transitionTo('organization.project.builds.build', buildId);
+    },
+
+    createReview(action, build, snapshots) {
+      const review = this.get('store').createRecord('review', {
+        build: build,
+        snapshots: snapshots,
+      });
+      return review.save().then(() => {
+        const build = this.modelFor(this.routeName);
+        build.get('snapshots').reload();
+        build.reload();
+      });
+    },
+  },
+});

--- a/app/routes/organization/project/builds/build/snapshot.js
+++ b/app/routes/organization/project/builds/build/snapshot.js
@@ -34,9 +34,10 @@ export default Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {
     });
   },
   actions: {
-    tmp() {
-      console.log('tmp');
+    closeSnapshotFullModal(buildId) {
+      this.transitionTo('organization.project.builds.build', buildId);
     },
+
     didTransition() {
       this._super(...arguments);
       // this.send('updateModalState', true);

--- a/app/routes/organization/project/builds/build/snapshot.js
+++ b/app/routes/organization/project/builds/build/snapshot.js
@@ -7,6 +7,9 @@ export default Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {
   queryParams: {
     comparisonMode: {as: 'mode'},
   },
+
+  isModalShowing: true,
+
   model(params /*transition*/) {
     this.set('params', params);
     let buildId = this.modelFor('organization.project.builds.build').get('id');
@@ -31,9 +34,12 @@ export default Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {
     });
   },
   actions: {
+    tmp() {
+      console.log('tmp');
+    },
     didTransition() {
       this._super(...arguments);
-      this.send('updateModalState', true);
+      // this.send('updateModalState', true);
 
       let build = this.modelFor(this.routeName);
       let organization = build.get('project.organization');

--- a/app/routes/organization/project/builds/build/snapshot.js
+++ b/app/routes/organization/project/builds/build/snapshot.js
@@ -8,8 +8,6 @@ export default Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {
     comparisonMode: {as: 'mode'},
   },
 
-  isModalShowing: true,
-
   model(params /*transition*/) {
     this.set('params', params);
     let buildId = this.modelFor('organization.project.builds.build').get('id');
@@ -40,7 +38,6 @@ export default Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {
 
     didTransition() {
       this._super(...arguments);
-      // this.send('updateModalState', true);
 
       let build = this.modelFor(this.routeName);
       let organization = build.get('project.organization');

--- a/app/routes/organization/project/builds/build/snapshot.js
+++ b/app/routes/organization/project/builds/build/snapshot.js
@@ -11,7 +11,13 @@ export default Route.extend(AuthenticatedRouteMixin, ResetScrollMixin, {
 
   model(params) {
     this.set('params', params);
-    const snapshot = this.store.findRecord('snapshot', params.snapshot_id);
+    // Try getting the snapshot from the store first.
+    let snapshot = this.store.peekRecord('snapshot', params.snapshot_id);
+    if (!snapshot) {
+      // If it's not in the store, make a query.
+      snapshot = this.store.findRecord('snapshot', params.snapshot_id);
+    }
+
     const build = this.modelFor('organization.project.builds.build');
     return hash({
       build,

--- a/app/styles/components/_build_container.scss
+++ b/app/styles/components/_build_container.scss
@@ -1,8 +1,4 @@
 .BuildContainer {
-  &.BuildContainer--snapshotModalOpen {
-    display: none;
-  }
-
   .BuildContainer-body {
     padding-top: 58px;
   }

--- a/app/templates/components/build-container.hbs
+++ b/app/templates/components/build-container.hbs
@@ -19,7 +19,6 @@
       build=build
       numSnapshotsUnchanged=numSnapshotsUnchanged
       showSnapshotFullModalTriggered=(action 'showSnapshotFullModalTriggered')
-      isShowingModal=isShowingModal
       createReview=createReview
     }}
   {{/if}}

--- a/app/templates/organization/project/builds/build.hbs
+++ b/app/templates/organization/project/builds/build.hbs
@@ -1,13 +1,1 @@
-{{!-- {{title model.buildTitle}}
-{{build-container
-  build=model
-  isSnapshotsLoading=isSnapshotsLoading
-  numSnapshotsUnchanged=numSnapshotsUnchanged
-  openSnapshotFullModal='openSnapshotFullModal'
-  isShowingModal=model.isShowingModal
-  createReview=(route-action "createReview")
-  snapshotsChanged=snapshotsChanged
-  initializeSnapshotOrdering=(route-action "initializeSnapshotOrdering")
-  showSupport=(route-action "showSupport")
-}} --}}
 {{outlet}}

--- a/app/templates/organization/project/builds/build/index.hbs
+++ b/app/templates/organization/project/builds/build/index.hbs
@@ -6,6 +6,7 @@
   createReview=(route-action "createReview")
   snapshotsChanged=snapshotsChanged
   snapshotsUnchanged=snapshotsUnchanged
+  numSnapshotsUnchanged=numSnapshotsUnchanged
   initializeSnapshotOrdering=(route-action "initializeSnapshotOrdering")
   showSupport=(route-action "showSupport")
 }}

--- a/app/templates/organization/project/builds/build/index.hbs
+++ b/app/templates/organization/project/builds/build/index.hbs
@@ -5,7 +5,6 @@
   toggleShowDiffs=(action "toggleShowDiffs")
   isSnapshotsLoading=isSnapshotsLoading
   openSnapshotFullModal='openSnapshotFullModal'
-  isShowingModal=model.isShowingModal
   createReview=(route-action "createReview")
   snapshotsChanged=snapshotsChanged
   snapshotsUnchanged=snapshotsUnchanged

--- a/app/templates/organization/project/builds/build/index.hbs
+++ b/app/templates/organization/project/builds/build/index.hbs
@@ -1,8 +1,6 @@
 {{title model.buildTitle}}
 {{build-container
   build=model
-  showDiffs=showDiffs
-  toggleShowDiffs=(action "toggleShowDiffs")
   isSnapshotsLoading=isSnapshotsLoading
   openSnapshotFullModal='openSnapshotFullModal'
   createReview=(route-action "createReview")

--- a/app/templates/organization/project/builds/build/index.hbs
+++ b/app/templates/organization/project/builds/build/index.hbs
@@ -1,13 +1,15 @@
-{{!-- {{title model.buildTitle}}
+{{title model.buildTitle}}
 {{build-container
   build=model
+  showDiffs=showDiffs
+  toggleShowDiffs=(action "toggleShowDiffs")
   isSnapshotsLoading=isSnapshotsLoading
-  numSnapshotsUnchanged=numSnapshotsUnchanged
   openSnapshotFullModal='openSnapshotFullModal'
   isShowingModal=model.isShowingModal
   createReview=(route-action "createReview")
   snapshotsChanged=snapshotsChanged
+  snapshotsUnchanged=snapshotsUnchanged
   initializeSnapshotOrdering=(route-action "initializeSnapshotOrdering")
   showSupport=(route-action "showSupport")
-}} --}}
+}}
 {{outlet}}

--- a/app/templates/organization/project/builds/build/snapshot.hbs
+++ b/app/templates/organization/project/builds/build/snapshot.hbs
@@ -4,9 +4,9 @@
     snapshotId=snapshotId
     snapshotSelectedWidth=snapshotSelectedWidth
     comparisonMode=comparisonMode
-    updateComparisonMode=(route-action 'tmp')
-    transitionRouteToWidth=(route-action 'tmp')
-    closeSnapshotFullModal=(route-action 'tmp')
-    createReview=(route-action "tmp")
+    updateComparisonMode=(route-action 'updateComparisonMode')
+    transitionRouteToWidth=(route-action 'transitionRouteToWidth')
+    closeSnapshotFullModal=(route-action 'closeSnapshotFullModal')
+    createReview=(route-action "createReview")
   }}
 {{/modal-dialog}}

--- a/app/templates/organization/project/builds/build/snapshot.hbs
+++ b/app/templates/organization/project/builds/build/snapshot.hbs
@@ -4,9 +4,9 @@
     snapshotId=snapshotId
     snapshotSelectedWidth=snapshotSelectedWidth
     comparisonMode=comparisonMode
-    updateComparisonMode=(route-action 'updateComparisonMode')
-    transitionRouteToWidth=(route-action 'transitionRouteToWidth')
-    closeSnapshotFullModal=(route-action 'closeSnapshotFullModal')
-    createReview=(route-action "createReview")
+    updateComparisonMode=(route-action 'tmp')
+    transitionRouteToWidth=(route-action 'tmp')
+    closeSnapshotFullModal=(route-action 'tmp')
+    createReview=(route-action "tmp")
   }}
 {{/modal-dialog}}

--- a/app/templates/organization/project/builds/build/snapshot.hbs
+++ b/app/templates/organization/project/builds/build/snapshot.hbs
@@ -1,6 +1,7 @@
 {{#modal-dialog wrapperClass="SnapshotViewerFullModalWrapper"}}
   {{snapshot-viewer-full
-    build=build
+    build=model.build
+    snapshot=model.snapshot
     snapshotId=snapshotId
     snapshotSelectedWidth=snapshotSelectedWidth
     comparisonMode=comparisonMode

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -254,6 +254,8 @@ export default function() {
     }
   });
 
+  this.get('/snapshots/:id');
+
   this.get('/builds/:id');
   this.get('/builds/:build_id/comparisons');
   this.get('/repos/:id');

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -230,8 +230,12 @@ describe('Acceptance: Fullscreen Snapshot', function() {
       project,
       createdAt: moment().subtract(2, 'minutes'),
       finishedAt: moment().subtract(5, 'seconds'),
+      totalSnapshots: 3,
     });
     snapshot = server.create('snapshot', 'withComparison', {build});
+    // Make some other snapshots for the build that should appear when closing the fullscreen view.
+    server.create('snapshot', 'withComparison', {build});
+    server.create('snapshot', 'noDiffs', {build});
 
     urlParams = {
       orgSlug: organization.slug,
@@ -275,6 +279,12 @@ describe('Acceptance: Fullscreen Snapshot', function() {
     await BuildPage.visitFullPageSnapshot(urlParams);
     BuildPage.snapshotFullscreen.header.clickDropdownToggle();
 
+    await percySnapshot(this.test);
+  });
+
+  it("fetches the build's snapshots when the fullscreen view is closed", async function() {
+    await BuildPage.visitFullPageSnapshot(urlParams);
+    await BuildPage.snapshotFullscreen.clickToggleFullScreen();
     await percySnapshot(this.test);
   });
 });

--- a/tests/integration/components/snapshot-viewer-full-test.js
+++ b/tests/integration/components/snapshot-viewer-full-test.js
@@ -46,7 +46,7 @@ describe('Integration: SnapshotViewerFull', function() {
     this.setProperties({
       build,
       snapshotSelectedWidth,
-      snapshotId: snapshot.get('id'),
+      snapshot,
       comparisonMode: 'diff',
       closeSnapshotFullModal: closeSnapshotFullModalStub,
       updateComparisonMode: updateComparisonModeStub,
@@ -55,7 +55,7 @@ describe('Integration: SnapshotViewerFull', function() {
     });
 
     this.render(hbs`{{snapshot-viewer-full
-      snapshotId=snapshotId
+      snapshot=snapshot
       build=build
       snapshotSelectedWidth=snapshotSelectedWidth
       comparisonMode=comparisonMode
@@ -94,7 +94,7 @@ describe('Integration: SnapshotViewerFull', function() {
     });
 
     it('shows "New" button when snapshot is new', function() {
-      this.set('snapshotId', addedSnapshot.get('id'));
+      this.set('snapshot', addedSnapshot);
 
       expect(FullSnapshotPage.isNewComparisonModeButtonVisible).to.equal(true);
       percySnapshot(this.test);

--- a/tests/pages/components/snapshot-viewer-full.js
+++ b/tests/pages/components/snapshot-viewer-full.js
@@ -43,6 +43,8 @@ export const SnapshotViewerFull = {
 
   isComparisonModeSwitcherVisible: alias('header.isComparisonModeSwitcherVisible'),
   isNewComparisonModeButtonVisible: alias('header.isNewComparisonModeButtonVisible'),
+
+  clickToggleFullScreen: alias('header.clickToggleFullscreen'),
 };
 
 export default create(SnapshotViewerFull);


### PR DESCRIPTION
This problem was because there were nested routes rendering into the same template. See issue here for more information: https://github.com/emberjs/ember.js/issues/2186

The solution is instead of using `builds/build` route, use `builds/build/index` route. Then when you transition between `builds/build/index` and `builds/build/snapshot` route, you'll transitioning between sibling routes rather than a child and a parent.

This refactor also allows the deletion of a bunch of modal management code. Going to the `builds/build/snapshot` route just shows the modal. There's no controlling the modal state, only controlling the route.

Fixes https://app.clubhouse.io/percy/story/1506/navigating-to-a-fullscreen-view-on-the-builds-page-and-back-results-in-a-blank-page