### PR TITLE
For large builds, only load images if in the viewport.

### DIFF
--- a/app/components/comparison-viewer.js
+++ b/app/components/comparison-viewer.js
@@ -5,6 +5,7 @@ export default Component.extend({
   // Arguments:
   comparison: null,
   allDiffsShown: null,
+  shouldDeferImageLoading: null,
 
   // State:
   classNames: ['ComparisonViewer bg-gray-000 border-bottom border-gray-100'],

--- a/app/components/image-spacer.js
+++ b/app/components/image-spacer.js
@@ -16,6 +16,8 @@ export default Component.extend(InViewportMixin, {
   deferredImageLoading: false,
   immediateImageLoading: not('deferredImageLoading'),
 
+  isHidingSpinner: false,
+
   // Whether or not the curent image is in the viewport.
   inViewport: alias('viewportEntered'),
 

--- a/app/components/image-spacer.js
+++ b/app/components/image-spacer.js
@@ -1,7 +1,7 @@
 import {setProperties} from '@ember/object';
 import {htmlSafe} from '@ember/string';
 import {computed} from '@ember/object';
-import {not, or} from '@ember/object/computed';
+import {not, or, alias} from '@ember/object/computed';
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
 
@@ -17,7 +17,7 @@ export default Component.extend(InViewportMixin, {
   immediateImageLoading: not('deferredImageLoading'),
 
   // Whether or not the curent image is in the viewport.
-  inViewport: false,
+  inViewport: alias('viewportEntered'),
 
   // We should load the image (ie. render the <img> tag) if deferred mode is off, or the image
   // is in the viewport.
@@ -45,14 +45,6 @@ export default Component.extend(InViewportMixin, {
         right: 0,
       },
     });
-  },
-
-  didEnterViewport() {
-    this.set('inViewport', true);
-  },
-
-  didExitViewport() {
-    this.set('inViewport', false);
   },
 
   click(e) {

--- a/app/components/image-spacer.js
+++ b/app/components/image-spacer.js
@@ -1,13 +1,27 @@
+import {setProperties} from '@ember/object';
 import {htmlSafe} from '@ember/string';
 import {computed} from '@ember/object';
+import {not, or} from '@ember/object/computed';
 import Component from '@ember/component';
+import InViewportMixin from 'ember-in-viewport';
 
-export default Component.extend({
+export default Component.extend(InViewportMixin, {
   image: null,
   imageClass: '',
 
   action: null,
   bubbles: true,
+
+  // Whether or not to defer image loading until in viewport.
+  deferredImageLoading: false,
+  immediateImageLoading: not('deferredImageLoading'),
+
+  // Whether or not the curent image is in the viewport.
+  inViewport: false,
+
+  // We should load the image (ie. render the <img> tag) if deferred mode is off, or the image
+  // is in the viewport.
+  shouldLoadImage: or('immediateImageLoading', 'inViewport'),
 
   classNames: ['ImageSpacer'],
   attributeBindings: ['style'],
@@ -15,6 +29,31 @@ export default Component.extend({
     let scale = this.get('image.height') * 100.0 / this.get('image.width');
     return htmlSafe(`padding-top: ${scale}%`);
   }),
+
+  init() {
+    this._super(...arguments);
+
+    setProperties(this, {
+      // Since adding listeners is memory intensive and can cause jank, disable viewport handling
+      // entirely if we are not doing deferred image loading.
+      viewportEnabled: this.get('deferredImageLoading'),
+      viewportTolerance: {
+        top: 0,
+        // Pre-emptively load 1000px worth of images below the viewport.
+        bottom: 1000,
+        left: 0,
+        right: 0,
+      },
+    });
+  },
+
+  didEnterViewport() {
+    this.set('inViewport', true);
+  },
+
+  didExitViewport() {
+    this.set('inViewport', false);
+  },
 
   click(e) {
     let action = this.get('action');

--- a/app/components/loading-page.js
+++ b/app/components/loading-page.js
@@ -2,4 +2,6 @@ import Component from '@ember/component';
 
 export default Component.extend({
   classNames: ['LoadingPage'],
+  attributeBindings: ['dataTestId:data-test-id'],
+  dataTestId: null,
 });

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -33,7 +33,7 @@ export default Component.extend({
   snapshotsUnchanged: null,
   activeSnapshotId: null,
 
-  shouldDeferImageLoading: gt('snapshotsChanged.length', 150),
+  shouldDeferImageLoading: gt('snapshotsChanged.length', 75),
 
   actions: {
     updateActiveSnapshotId(newSnapshotId) {

--- a/app/components/snapshot-list.js
+++ b/app/components/snapshot-list.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {alias, lt, mapBy} from '@ember/object/computed';
+import {alias, gt, mapBy} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 import {inject as service} from '@ember/service';
@@ -33,7 +33,7 @@ export default Component.extend({
   snapshotsUnchanged: null,
   activeSnapshotId: null,
 
-  isDefaultExpanded: lt('snapshotsChanged.length', 150),
+  shouldDeferImageLoading: gt('snapshotsChanged.length', 150),
 
   actions: {
     updateActiveSnapshotId(newSnapshotId) {

--- a/app/components/snapshot-viewer.js
+++ b/app/components/snapshot-viewer.js
@@ -55,13 +55,12 @@ export default Component.extend({
     this.set('_shouldScroll', true);
   }),
 
-  isDefaultExpanded: true,
   isFocus: alias('isActiveSnapshot'),
   isExpanded: or('isUserExpanded', '_isDefaultExpanded'),
   isUserExpanded: false,
 
   _isDefaultExpanded: computed(
-    'isDefaultExpanded',
+    'shouldDeferImageLoading',
     'snapshot.isApproved',
     'build.isApproved',
     'isActiveSnapshot',
@@ -71,7 +70,7 @@ export default Component.extend({
       } else if (this.get('snapshot.isApproved')) {
         return false;
       } else {
-        return this.get('isDefaultExpanded');
+        return true;
       }
     },
   ),

--- a/app/templates/components/comparison-viewer.hbs
+++ b/app/templates/components/comparison-viewer.hbs
@@ -4,18 +4,31 @@
       <div class="ComparisonViewer-halfColumn ComparisonViewer-halfColumn--left">
         {{#with comparison.baseScreenshot.lossyImage as |image|}}
           <div class="Viewer-pdiffImageBox" style={{html-safe "max-width: " image.width "px"}}>
-            {{image-spacer image=image imageClass="ComparisonViewer-pdiffImage"}}
+            {{image-spacer
+              image=image
+              imageClass="ComparisonViewer-pdiffImage"
+              deferredImageLoading=shouldDeferImageLoading
+            }}
           </div>
         {{/with}}
       </div>
       <div class="ComparisonViewer-halfColumn ComparisonViewer-halfColumn--right">
         {{#with comparison.headScreenshot.lossyImage as |lossyImage|}}
           <div class="Viewer-pdiffImageBox Viewer-pdiffImageBox--actionable" style={{html-safe "max-width: " lossyImage.width "px"}} data-test-comparison-viewer-diff-image-container>
-            {{image-spacer action=(action "toggleOverlay") image=lossyImage imageClass="ComparisonViewer-pdiffImage ComparisonViewer-pdiffImage--actionable"}}
+            {{image-spacer
+              action=(action "toggleOverlay")
+              image=lossyImage
+              imageClass="ComparisonViewer-pdiffImage ComparisonViewer-pdiffImage--actionable"
+              deferredImageLoading=shouldDeferImageLoading
+              }}
             {{#if showDiffOverlay}}
               {{#with comparison.diffImage as |diffImage|}}
                 <div class="pdiffImageOverlay" data-test-comparison-viewer-full-diff-image-overlay>
-                  {{image-spacer action=(action "toggleOverlay") image=diffImage imageClass="Viewer-pdiffImageOverlay"}}
+                  {{image-spacer
+                    image=diffImage
+                    imageClass="Viewer-pdiffImageOverlay"
+                    action=(action "toggleOverlay")
+                  }}
                 </div>
               {{/with}}
             {{/if}}
@@ -64,7 +77,11 @@
       <div class="ComparisonViewer-halfColumn ComparisonViewer-halfColumn--right">
         {{#with comparison.headScreenshot.lossyImage as |image|}}
           <div class="Viewer-pdiffImageBox" style={{html-safe "max-width: " image.width "px"}}>
-            {{image-spacer image=image imageClass="ComparisonViewer-pdiffImage"}}
+            {{image-spacer
+              image=image
+              imageClass="ComparisonViewer-pdiffImage"
+              deferredImageLoading=shouldDeferImageLoading
+            }}
           </div>
         {{/with}}
       </div>

--- a/app/templates/components/comparison-viewer.hbs
+++ b/app/templates/components/comparison-viewer.hbs
@@ -31,6 +31,7 @@
                     imageClass="Viewer-pdiffImageOverlay"
                     action=(action "toggleOverlay")
                     deferredImageLoading=shouldDeferImageLoading
+                    isHidingSpinner=true
                   }}
                 </div>
               {{/with}}

--- a/app/templates/components/comparison-viewer.hbs
+++ b/app/templates/components/comparison-viewer.hbs
@@ -28,6 +28,7 @@
                     image=diffImage
                     imageClass="Viewer-pdiffImageOverlay"
                     action=(action "toggleOverlay")
+                    deferredImageLoading=shouldDeferImageLoading
                   }}
                 </div>
               {{/with}}

--- a/app/templates/components/comparison-viewer.hbs
+++ b/app/templates/components/comparison-viewer.hbs
@@ -8,6 +8,7 @@
               image=image
               imageClass="ComparisonViewer-pdiffImage"
               deferredImageLoading=shouldDeferImageLoading
+              dataTestId="comparison-viewer-base-image-loading"
             }}
           </div>
         {{/with}}
@@ -20,6 +21,7 @@
               image=lossyImage
               imageClass="ComparisonViewer-pdiffImage ComparisonViewer-pdiffImage--actionable"
               deferredImageLoading=shouldDeferImageLoading
+              dataTestId="comparison-viewer-head-image-loading"
               }}
             {{#if showDiffOverlay}}
               {{#with comparison.diffImage as |diffImage|}}

--- a/app/templates/components/image-spacer.hbs
+++ b/app/templates/components/image-spacer.hbs
@@ -1,5 +1,5 @@
 {{#if shouldLoadImage}}
   {{simple-image image=image classes=imageClass}}
-{{else}}
+{{else if (not deferredImageLoading)}}
   {{loading-page}}
 {{/if}}

--- a/app/templates/components/image-spacer.hbs
+++ b/app/templates/components/image-spacer.hbs
@@ -1,5 +1,5 @@
 {{#if shouldLoadImage}}
   {{simple-image image=image classes=imageClass}}
 {{else if (not deferredImageLoading)}}
-  {{loading-page}}
+  {{loading-page dataTestId=dataTestId}}
 {{/if}}

--- a/app/templates/components/image-spacer.hbs
+++ b/app/templates/components/image-spacer.hbs
@@ -1,5 +1,6 @@
 {{#if shouldLoadImage}}
   {{simple-image image=image classes=imageClass}}
-{{else if (not deferredImageLoading)}}
+{{else if isHidingSpinner}}
+{{else}}
   {{loading-page dataTestId=dataTestId}}
 {{/if}}

--- a/app/templates/components/image-spacer.hbs
+++ b/app/templates/components/image-spacer.hbs
@@ -1,3 +1,5 @@
 {{#if shouldLoadImage}}
   {{simple-image image=image classes=imageClass}}
+{{else}}
+  {{loading-page}}
 {{/if}}

--- a/app/templates/components/image-spacer.hbs
+++ b/app/templates/components/image-spacer.hbs
@@ -1,1 +1,3 @@
-{{simple-image image=image classes=imageClass}}
+{{#if shouldLoadImage}}
+  {{simple-image image=image classes=imageClass}}
+{{/if}}

--- a/app/templates/components/snapshot-list.hbs
+++ b/app/templates/components/snapshot-list.hbs
@@ -1,17 +1,10 @@
-{{#unless isDefaultExpanded}}
-  <div class="Alert Alert--warning text-center">
-    <strong>Whew!</strong> There are too many snapshots to show all at once, so they
-    are collapsed below. <strong>Tip:</strong> use the arrow keys <code>↓</code> and <code>↑</code> to move around.
-  </div>
-{{/unless}}
-
 {{#each snapshotsChanged as |snapshot|}}
   {{snapshot-viewer
     build=build
     snapshot=snapshot
     allDiffsShown=allDiffsShown
     activeSnapshotId=activeSnapshotId
-    isDefaultExpanded=isDefaultExpanded
+    shouldDeferImageLoading=shouldDeferImageLoading
     showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
     createReview=createReview
     updateActiveSnapshotId=(action "updateActiveSnapshotId")
@@ -41,7 +34,7 @@
         allDiffsShown=allDiffsShown
         snapshot=snapshot
         activeSnapshotId=activeSnapshotId
-        isDefaultExpanded=isDefaultExpanded
+        shouldDeferImageLoading=shouldDeferImageLoading
         showSnapshotFullModalTriggered=showSnapshotFullModalTriggered
         createReview=createReview
         updateActiveSnapshotId=(action "updateActiveSnapshotId")

--- a/app/templates/components/snapshot-viewer.hbs
+++ b/app/templates/components/snapshot-viewer.hbs
@@ -15,7 +15,7 @@
       comparison=selectedComparison
       allDiffsShown=allDiffsShown
       snapshotSelectedWidth=snapshotSelectedWidth
-      isDefaultExpanded=isDefaultExpanded
+      shouldDeferImageLoading=shouldDeferImageLoading
       isUnchangedSnapshotExpanded=isUnchangedSnapshotExpanded
       data-test-SnapshotViewer-comparison=true
     }}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "ember-fakerjs": "^0.2.0",
     "ember-font-awesome": "^3.1.1",
     "ember-inflector": "^3.0.0",
+    "ember-in-viewport": "^3.0.2",
     "ember-inline-svg": "^0.1.11",
     "ember-load-initializers": "^1.1.0",
     "ember-modal-dialog": "^2.4.0",

--- a/tests/factories/comparison.js
+++ b/tests/factories/comparison.js
@@ -1,5 +1,6 @@
 import FactoryGuy from 'ember-data-factory-guy';
 import moment from 'moment';
+import {make} from 'ember-data-factory-guy';
 
 export const TEST_COMPARISON_WIDTHS = [375, 550, 1024];
 
@@ -8,35 +9,30 @@ FactoryGuy.define('comparison', {
     startedProcessingAt: () => moment().subtract(65, 'seconds'),
     finishedProcessingAt: () => moment().subtract(23, 'seconds'),
     diffRatio: 0.23,
+    width: 1024,
     browser: () => {
       return FactoryGuy.make('browser');
     },
 
-    headScreenshot: f => {
-      // TODO: make the screenshot and image a real FactoryGuy model instead of POJO
-      return {
-        id: f.id,
-        image: {id: f.id, url: '/images/test/v2.png', width: 375, height: 500},
-        lossyImage: {id: f.id, url: '/images/test/v2-lossy.png', width: 375, height: 500},
-      };
+    baseScreenshot: () => {
+      return FactoryGuy.make('screenshot', 'base');
     },
-    baseScreenshot: f => {
-      // TODO: make the screenshot and image a real FactoryGuy model instead of POJO
-      return {
-        id: f.id,
-        image: {id: f.id, url: '/images/test/v1.png', width: 375, height: 500},
-        lossyImage: {id: f.id, url: '/images/test/v1-lossy.png', width: 375, height: 500},
-      };
+    headScreenshot: () => {
+      return FactoryGuy.make('screenshot', 'head');
     },
-    diffImage: f => {
-      // TODO: make the screenshot and image a real FactoryGuy model instead of POJO
-      return {id: f.id, image: {id: f.id, url: '/images/test/diff.png', width: 375, height: 500}};
+    diffImage: () => {
+      return FactoryGuy.make('image', 'diffImage');
     },
   },
 
   traits: {
     new: {
       baseScreenshot: null,
+    },
+    short: {
+      baseScreenshot: () => make('screenshot', 'baseShort'),
+      headScreenshot: () => make('screenshot', 'headShort'),
+      diffImage: () => make('image', 'diffImage', 'short'),
     },
   },
 });

--- a/tests/factories/image.js
+++ b/tests/factories/image.js
@@ -1,0 +1,32 @@
+import FactoryGuy from 'ember-data-factory-guy';
+import moment from 'moment';
+
+FactoryGuy.define('image', {
+  default: {
+    sha: '39e9d27ba78f728924e2e8a9579e8ef4b4968217363eacef6b1bda4bd3c22c58',
+    mimetype: 'image/png',
+    url: '/images/test/v2.png',
+    width: 375,
+    height: 500,
+    createdAt: moment().subtract(3, 'days'),
+    updatedAt: moment().subtract(1, 'days'),
+  },
+
+  traits: {
+    short: {
+      height: 100,
+    },
+    headImageLossy: {
+      url: '/images/test/v2-lossy.jpg',
+    },
+    baseImage: {
+      url: '/images/test/v1.png',
+    },
+    baseImageLossy: {
+      url: '/images/test/v1-lossy.jpg',
+    },
+    diffImage: {
+      url: '/images/test/diff.png',
+    },
+  },
+});

--- a/tests/factories/screenshot.js
+++ b/tests/factories/screenshot.js
@@ -1,0 +1,38 @@
+import FactoryGuy from 'ember-data-factory-guy';
+import moment from 'moment';
+import {make} from 'ember-data-factory-guy';
+
+FactoryGuy.define('screenshot', {
+  default: {
+    snapshot: FactoryGuy.belongsTo('snapshot'),
+    image: FactoryGuy.belongsTo('image'),
+    lossyImage: FactoryGuy.belongsTo('image'),
+    createdAt: moment().subtract(3, 'days'),
+    updatedAt: moment().subtract(1, 'days'),
+  },
+
+  traits: {
+    head: {
+      image: () => make('image'),
+      lossyImage: () => make('image', 'headImageLossy'),
+    },
+    headShort: {
+      image: () => make('image', 'short'),
+      lossyImage: () => make('image', 'headImageLossy', 'short'),
+    },
+    base: {
+      image: () => make('image', 'baseImage'),
+      lossyImage: () => make('image', 'baseImageLossy'),
+    },
+    baseShort: {
+      image: () => make('image', 'baseImage', 'short'),
+      lossyImage: () => make('image', 'baseImageLossy', 'short'),
+    },
+    diff: {
+      image: () => make('image', 'diffImage'),
+    },
+    diffShort: {
+      image: () => make('image', 'diffImage', 'short'),
+    },
+  },
+});

--- a/tests/integration/components/snapshot-list-test.js
+++ b/tests/integration/components/snapshot-list-test.js
@@ -94,11 +94,10 @@ describe('Integration: SnapshotList', function() {
     percySnapshot(this.test);
   });
 
-  describe('when there are more than 150 snapshots with diffs', function() {
-    const numSnapshots = 151;
+  describe('when there are more than 75 snapshots with diffs', function() {
+    const numSnapshots = 76;
 
     beforeEach(function() {
-      this.timeout(6000);
       const stub = sinon.stub();
       const build = make('build', 'finished');
 

--- a/tests/integration/components/snapshot-list-test.js
+++ b/tests/integration/components/snapshot-list-test.js
@@ -120,36 +120,13 @@ describe('Integration: SnapshotList', function() {
       }}`);
     });
 
-    it('collapses all snapshots by default', function() {
+    it('lazy loads comparison images', function() {
       expect(SnapshotList.snapshots().count).to.equal(numSnapshots);
       SnapshotList.snapshots().forEach(snapshot => {
-        expect(snapshot.isCollapsed).to.equal(true);
+        expect(snapshot.isBaseLoadingSpinnerPresent).to.equal(true);
+        expect(snapshot.isHeadLoadingSpinnerPresent).to.equal(true);
       });
       percySnapshot(this.test);
-    });
-
-    it('allows keyboard nav with up and down arrows', function() {
-      SnapshotList.typeDownArrow();
-      wait();
-      expect(SnapshotList.snapshots(0).isExpanded).to.equal(true);
-      expect(SnapshotList.snapshots(0).isFocused).to.equal(true);
-      expect(SnapshotList.snapshots(1).isExpanded).to.equal(false);
-      expect(SnapshotList.snapshots(1).isFocused).to.equal(false);
-      percySnapshot(this.test);
-
-      SnapshotList.typeDownArrow();
-      wait();
-      expect(SnapshotList.snapshots(0).isExpanded).to.equal(false);
-      expect(SnapshotList.snapshots(0).isFocused).to.equal(false);
-      expect(SnapshotList.snapshots(1).isExpanded).to.equal(true);
-      expect(SnapshotList.snapshots(1).isFocused).to.equal(true);
-
-      SnapshotList.typeUpArrow();
-      wait();
-      expect(SnapshotList.snapshots(0).isExpanded).to.equal(true);
-      expect(SnapshotList.snapshots(0).isFocused).to.equal(true);
-      expect(SnapshotList.snapshots(1).isExpanded).to.equal(false);
-      expect(SnapshotList.snapshots(1).isFocused).to.equal(false);
     });
   });
 

--- a/tests/integration/components/snapshot-list-test.js
+++ b/tests/integration/components/snapshot-list-test.js
@@ -98,10 +98,15 @@ describe('Integration: SnapshotList', function() {
     const numSnapshots = 151;
 
     beforeEach(function() {
+      this.timeout(6000);
       const stub = sinon.stub();
       const build = make('build', 'finished');
 
-      const snapshotsChanged = makeList('snapshot', numSnapshots, 'withComparisons', {build});
+      const snapshotsChanged = makeList('snapshot', numSnapshots, {build});
+      snapshotsChanged.forEach(snapshot => {
+        snapshot.set('comparisons', [make('comparison', 'short')]);
+      });
+
       this.set('snapshotsChanged', snapshotsChanged);
 
       this.setProperties({

--- a/tests/integration/components/snapshot-viewer-test.js
+++ b/tests/integration/components/snapshot-viewer-test.js
@@ -43,7 +43,7 @@ describe('Integration: SnapshotViewer', function() {
       showSnapshotFullModalTriggered: showSnapshotFullModalTriggeredStub,
       createReview: createReviewStub,
       // true is the default in the component
-      isDefaultExpanded: true,
+      shouldDeferImageLoading: true,
     });
   });
 
@@ -212,15 +212,6 @@ describe('Integration: SnapshotViewer', function() {
     it('is collapsed by default when the snapshot is approved', function() {
       this.set('snapshot.reviewState', SNAPSHOT_APPROVED_STATE);
       expect(SnapshotViewerPO.isExpanded).to.equal(false);
-    });
-
-    it('is collapsed when isDefaultExpanded is false', function() {
-      this.set('snapshot.reviewState', SNAPSHOT_UNAPPROVED_STATE);
-      this.set('isDefaultExpanded', false);
-
-      return wait(() => {
-        expect(SnapshotViewerPO.isExpanded).to.equal(false);
-      });
     });
 
     it('is expanded when build is approved', function() {

--- a/tests/pages/components/snapshot-viewer.js
+++ b/tests/pages/components/snapshot-viewer.js
@@ -1,6 +1,13 @@
-import {create, isVisible, clickable, hasClass, notHasClass} from 'ember-cli-page-object';
 import {SnapshotViewerHeader} from 'percy-web/tests/pages/components/snapshot-viewer-header';
 import {alias} from 'ember-cli-page-object/macros';
+import {
+  create,
+  isVisible,
+  isPresent,
+  clickable,
+  hasClass,
+  notHasClass,
+} from 'ember-cli-page-object';
 
 const SELECTORS = {
   SNAPSHOT_VIEWER: '[data-test-snapshot-viewer]',
@@ -8,6 +15,8 @@ const SELECTORS = {
   DIFF_IMAGE_BOX: '[data-test-comparison-viewer-diff-image-container] img',
   NO_DIFF_BOX: '[data-test-comparison-viewer-unchanged]',
   SHOW_UNCHANGED_COMPARISONS: '[data-test-comaprison-viewer-show-unchanged-comparisons]',
+  BASE_SNAPSHOT_LOADING_SPINNER: '[data-test-id=comparison-viewer-base-image-loading]',
+  HEAD_SNAPSHOT_LOADING_SPINNER: '[data-test-id=comparison-viewer-head-image-loading]',
 };
 
 export const SnapshotViewer = {
@@ -30,6 +39,9 @@ export const SnapshotViewer = {
 
   isDiffImageBoxVisible: isVisible(SELECTORS.DIFF_IMAGE_BOX),
   clickDiffImageBox: clickable(SELECTORS.DIFF_IMAGE_BOX),
+
+  isBaseLoadingSpinnerPresent: isPresent(SELECTORS.BASE_SNAPSHOT_LOADING_SPINNER),
+  isHeadLoadingSpinnerPresent: isPresent(SELECTORS.HEAD_SNAPSHOT_LOADING_SPINNER),
 
   isNoDiffBoxVisible: isVisible(SELECTORS.NO_DIFF_BOX),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,6 +3908,12 @@ ember-ignore-children-helper@^1.0.0:
   dependencies:
     ember-cli-babel "^6.8.2"
 
+ember-in-viewport@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/ember-in-viewport/-/ember-in-viewport-3.0.2.tgz#bee66f564e68f397ebc2d31b7a3619394ac933d0"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-inflector@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.1.0.tgz#afcb92d022a4eab58f08ff4578eafc3a1de2d09b"


### PR DESCRIPTION
https://app.clubhouse.io/percy/story/1829/improve-experience-for-large-builds-with-many-changes

This was mostly an experiment based on today's discussion, but seems to work really well. It is also only enabled for builds with > 150 changed snapshots, otherwise behavior is unchanged.

Questions: 
Why is deferredImageLoading only passed to some image-spacer components?
What is the deal with _isExpanded property?
What is the correct number for when deferred loading should kick in ?