### PR TITLE
Prevent full screen squishing

### DIFF
--- a/app/styles/components/_comparison_viewer_full.scss
+++ b/app/styles/components/_comparison_viewer_full.scss
@@ -2,6 +2,7 @@
   text-align: center;
 
   img {
+    max-width: none;
     box-shadow: 0 0 0 1px var(--very-light-gray);
   }
 


### PR DESCRIPTION
After giving it a good go for an hour or so, my first solution ended up being the final one on this. I would really prefer the `img` to be centered horizontally on load, but the box model just doesn't play nice like that with overflow and scrolling. There can be a solution to this but will take some sorcery. This added line of code will prevent the full res images from squishing down in a browser but will start its initial position on load in the top left of the window rather than horizontally centered. Not a _huge_ deal but just not my preference. Maybe this is other's preference, but it's fixed nonetheless :)