### PR TITLE
Remove some computed style deprecations

### DIFF
--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -2,6 +2,7 @@ import {or} from '@ember/object/computed';
 import Component from '@ember/component';
 import {computed, get} from '@ember/object';
 import {alias} from '@ember/object/computed';
+import {htmlSafe} from '@ember/string';
 
 export default Component.extend({
   build: null,
@@ -14,7 +15,7 @@ export default Component.extend({
   }),
 
   progressBarWidthStyle: computed('progressBarWidth', function() {
-    return `--progress-bar-width: ${get(this, 'progressBarWidth')}`.htmlSafe();
+    return htmlSafe(`--progress-bar-width: ${get(this, 'progressBarWidth')}`);
   }),
 
   showActions: or('build.isPending', 'build.isProcessing', 'build.isFinished'),

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -1,6 +1,6 @@
 import {or} from '@ember/object/computed';
 import Component from '@ember/component';
-import {computed} from '@ember/object';
+import {computed, get} from '@ember/object';
 import {alias} from '@ember/object/computed';
 
 export default Component.extend({
@@ -10,12 +10,16 @@ export default Component.extend({
   buildCompletionPercent: alias('build.buildCompletionPercent'),
 
   progressBarWidth: computed('buildCompletionPercent', function() {
-    return `${this.get('buildCompletionPercent') - 100}%`;
+    return `${get(this, 'buildCompletionPercent') - 100}%`;
+  }),
+
+  progressBarWidthStyle: computed('progressBarWidth', function() {
+    return `--progress-bar-width: ${get(this, 'progressBarWidth')}`.htmlSafe();
   }),
 
   showActions: or('build.isPending', 'build.isProcessing', 'build.isFinished'),
 
   formattedFailedSnapshots: computed('build.failureDetails', function() {
-    return '"' + this.get('build.failureDetails').failed_snapshots.join('", "') + '"';
+    return '"' + get(this, 'build.failureDetails').failed_snapshots.join('", "') + '"';
   }),
 });

--- a/app/components/team-member.js
+++ b/app/components/team-member.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
 import Component from '@ember/component';
 import {computed} from '@ember/object';
 import seededRandom from 'percy-web/lib/random';
+import {htmlSafe} from '@ember/string';
 
 export default Component.extend({
   tagName: '',
 
   setGridItemOrder: computed(function() {
-    return Ember.String.htmlSafe('order: ' + Math.floor(seededRandom() * 100 + 1));
+    return htmlSafe('order: ' + Math.floor(seededRandom() * 100 + 1));
   }),
 });

--- a/app/components/team-member.js
+++ b/app/components/team-member.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Component from '@ember/component';
 import {computed} from '@ember/object';
 import seededRandom from 'percy-web/lib/random';
@@ -6,6 +7,6 @@ export default Component.extend({
   tagName: '',
 
   setGridItemOrder: computed(function() {
-    return Math.floor(seededRandom() * 100 + 1);
+    return Ember.String.htmlSafe('order: ' + Math.floor(seededRandom() * 100 + 1));
   }),
 });

--- a/app/components/team-member.js
+++ b/app/components/team-member.js
@@ -1,13 +1,11 @@
 import Component from '@ember/component';
+import {computed} from '@ember/object';
 import seededRandom from 'percy-web/lib/random';
 
 export default Component.extend({
-  classNames: ['team-member', 'mb-7'],
-  attributeBindings: ['style'],
-  style: '',
+  tagName: '',
 
-  setGridItemOrder: function() {
-    let gridItemOrder = Math.floor(seededRandom() * 100 + 1);
-    this.set('style', 'order: ' + gridItemOrder);
-  }.on('didInsertElement'),
+  setGridItemOrder: computed(function() {
+    return Math.floor(seededRandom() * 100 + 1);
+  }),
 });

--- a/app/lib/random.js
+++ b/app/lib/random.js
@@ -2,7 +2,8 @@ import config from 'percy-web/config/environment';
 
 export default function() {
   if (config.environment === 'test') {
-    return Math.seedrandom('randomseed');
+    Math.seedrandom('randomseed');
+    return Math.random();
   } else {
     return Math.random();
   }

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -1,7 +1,7 @@
 <div class="build-header position-relative flex justify-between align-center py-3 pr-2 pl-3 is-{{dasherize build.state}} is-{{if build.isFinished (dasherize build.reviewState)}} border-bottom border-gray-000">
   {{#unless build.isFinished}}
-    <div class="progress-bar-subtle position-absolute" style="--progress-bar-width: {{progressBarWidth}}"></div>
-    <div class="progress-bar position-absolute" style="--progress-bar-width: {{progressBarWidth}}"></div>
+    <div class="progress-bar-subtle position-absolute" style={{progressBarWidthStyle}}></div>
+    <div class="progress-bar position-absolute" style={{progressBarWidthStyle}}></div>
   {{/unless}}
   {{build-overview-info build=build}}
   <div class="text-right">

--- a/app/templates/components/team-member.hbs
+++ b/app/templates/components/team-member.hbs
@@ -1,4 +1,4 @@
-<div class="team-member mb-7" style="order: {{setGridItemOrder}}">
+<div class="team-member mb-7" style={{setGridItemOrder}}>
   <img src="{{img}}" alt="team-member-photo" class="team-member-photo">
   <div class="social-toolbar flex justify-center">
     <div class="social-toolbar-items flex align-center px-1">

--- a/app/templates/components/team-member.hbs
+++ b/app/templates/components/team-member.hbs
@@ -1,42 +1,44 @@
-<img src="{{img}}" alt="team-member-photo" class="team-member-photo">
-<div class="social-toolbar flex justify-center">
-  <div class="social-toolbar-items flex align-center px-1">
-    {{#if social-twitter}}
-      <a href="http://www.twitter.com/{{social-twitter}}" class="social-toolbar-item">
-        {{inline-svg "twitter-icon"}}
-      </a>
-    {{/if}}
-    {{#if social-instagram}}
-      <a href="http://www.instagram.com/{{social-instagram}}" class="social-toolbar-item">
-        {{inline-svg "instagram-icon"}}
-      </a>
-    {{/if}}
-    {{#if social-github}}
-      <a href="http://www.github.com/{{social-github}}" class="social-toolbar-item">
-        {{inline-svg "github-icon"}}
-      </a>
-    {{/if}}
-    {{#if social-linkedin}}
-      <a href="http://www.linkedin.com/in/{{social-linkedin}}" class="social-toolbar-item">
-        {{inline-svg "linkedin-icon"}}
-      </a>
-    {{/if}}
-    {{#if social-website}}
-      <a href="http://www.{{social-website}}" class="social-toolbar-item">
-        {{inline-svg "website-icon"}}
-      </a>
-    {{/if}}
-    {{#if social-photos}}
-      <a href="{{social-photos}}" class="social-toolbar-item">
-        {{inline-svg "photos-icon"}}
-      </a>
-    {{/if}}
+<div class="team-member mb-7" style="order: {{setGridItemOrder}}">
+  <img src="{{img}}" alt="team-member-photo" class="team-member-photo">
+  <div class="social-toolbar flex justify-center">
+    <div class="social-toolbar-items flex align-center px-1">
+      {{#if social-twitter}}
+        <a href="http://www.twitter.com/{{social-twitter}}" class="social-toolbar-item">
+          {{inline-svg "twitter-icon"}}
+        </a>
+      {{/if}}
+      {{#if social-instagram}}
+        <a href="http://www.instagram.com/{{social-instagram}}" class="social-toolbar-item">
+          {{inline-svg "instagram-icon"}}
+        </a>
+      {{/if}}
+      {{#if social-github}}
+        <a href="http://www.github.com/{{social-github}}" class="social-toolbar-item">
+          {{inline-svg "github-icon"}}
+        </a>
+      {{/if}}
+      {{#if social-linkedin}}
+        <a href="http://www.linkedin.com/in/{{social-linkedin}}" class="social-toolbar-item">
+          {{inline-svg "linkedin-icon"}}
+        </a>
+      {{/if}}
+      {{#if social-website}}
+        <a href="http://www.{{social-website}}" class="social-toolbar-item">
+          {{inline-svg "website-icon"}}
+        </a>
+      {{/if}}
+      {{#if social-photos}}
+        <a href="{{social-photos}}" class="social-toolbar-item">
+          {{inline-svg "photos-icon"}}
+        </a>
+      {{/if}}
+    </div>
   </div>
-</div>
-<div class="team-member-name f4 text-weight-semibold text-center">{{name}}</div>
-<div class="team-member-title text-light text-center mb-1">{{title}}</div>
-<div class="label-container pr-4">
-  {{#each labels as |label|}}
-    <div class="label">{{label}}</div>
-  {{/each}}
+  <div class="team-member-name f4 text-weight-semibold text-center">{{name}}</div>
+  <div class="team-member-title text-light text-center mb-1">{{title}}</div>
+  <div class="label-container pr-4">
+    {{#each labels as |label|}}
+      <div class="label">{{label}}</div>
+    {{/each}}
+  </div>
 </div>


### PR DESCRIPTION
## Description
Our buildkite logs are too big to display all of them at once and that is ridiculous. In an effort to make this reasonable, let's remove some of the chatter in the logs. One noisy test is the teams page, it is unhappy about assigning the style attribute in that dynamic way so I've moved the random calculation into the JS.

## Pictures
:(
![image](https://user-images.githubusercontent.com/3179218/40259820-9736cc10-5aac-11e8-81cc-d84c35ab7e03.png)

_**Is Covered by Automated Tests?: YES/NO**_
Covered by a Percy test

This should not affect how users see the Teams page (although the random sort may be different initially in the Percy test)

### Update:
Woohoo, this is enough to push our test output to fit on one page (76 warnings)...but let's keep getting rid of these notices :D