### PR TITLE
[Performance] Do not re-fetch snapshots when navigating a build.

### DIFF
--- a/app/components/build-container.js
+++ b/app/components/build-container.js
@@ -10,7 +10,6 @@ import {task} from 'ember-concurrency';
 export default Component.extend(PollingMixin, {
   classNames: ['BuildContainer'],
   classNameBindings: ['isHidingBuildContainer:BuildContainer--snapshotModalOpen'],
-  store: service(),
 
   build: null,
   isHidingBuildContainer: false,
@@ -54,9 +53,12 @@ export default Component.extend(PollingMixin, {
   },
 
   _getLoadedSnapshots() {
-    return this.get('store')
-      .peekAll('snapshot')
-      .filterBy('build.id', this.get('build.id'));
+    // Get snapshots without making new request
+    return (
+      this.get('build')
+        .hasMany('snapshots')
+        .value() || []
+    );
   },
 
   isUnchangedSnapshotsLoading: readOnly('_toggleUnchangedSnapshotsVisible.isRunning'),

--- a/app/controllers/organization/project/builds/build.js
+++ b/app/controllers/organization/project/builds/build.js
@@ -21,7 +21,9 @@ export default Controller.extend({
   initializeSnapshotOrdering() {
     const orderedBrowserSnapshots = {};
     const browsers = this.get('build.browsers');
-    const buildSnapshots = this.get('build.snapshots');
+    const buildSnapshots = this.get('store')
+      .peekAll('snapshot')
+      .filterBy('build.id', this.get('build.id'));
 
     browsers.forEach(browser => {
       const snapshotsWithDiffs = snapshotsWithDiffForBrowser(buildSnapshots, browser);

--- a/app/controllers/organization/project/builds/build.js
+++ b/app/controllers/organization/project/builds/build.js
@@ -21,9 +21,11 @@ export default Controller.extend({
   initializeSnapshotOrdering() {
     const orderedBrowserSnapshots = {};
     const browsers = this.get('build.browsers');
-    const buildSnapshots = this.get('store')
-      .peekAll('snapshot')
-      .filterBy('build.id', this.get('build.id'));
+    // Get snapshots without making new request
+    const buildSnapshots =
+      this.get('build')
+        .hasMany('snapshots')
+        .value() || [];
 
     browsers.forEach(browser => {
       const snapshotsWithDiffs = snapshotsWithDiffForBrowser(buildSnapshots, browser);

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -191,7 +191,7 @@ export default DS.Model.extend({
     'unreviewedSnapshotsWithDiffs.[]',
     'browsers.[]',
     function() {
-      const loadedSnapshotsForBuild = this.get('store')
+      const loadedSnapshotsForBuild = this.store
         .peekAll('snapshot')
         .filterBy('build.id', this.get('id'));
 

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -183,18 +183,19 @@ export default DS.Model.extend({
     return this.store.findRecord('build', this.get('id'), {reload: true});
   },
 
+  loadedSnapshots: computed(function() {
+    return this.store.peekAll('snapshot').filterBy('build.id', this.get('id'));
+  }),
+
   // Returns Ember Object with a property for each browser for the build,
   // where the value is an array of snapshots that have diffs for that browser.
   // It is an ember object rather than a POJO so computed properties can observe it, and for ease
   // of use in templates.
   unapprovedSnapshotsWithDiffForBrowsers: computed(
-    'unreviewedSnapshotsWithDiffs.[]',
+    'loadedSnapshots.@each.{isUnreviewed,isUnchanged}',
     'browsers.[]',
     function() {
-      const loadedSnapshotsForBuild = this.store
-        .peekAll('snapshot')
-        .filterBy('build.id', this.get('id'));
-
+      const loadedSnapshotsForBuild = this.get('loadedSnapshots');
       const unreviewedSnapshotsWithDiffs = loadedSnapshotsForBuild.reduce((acc, snapshot) => {
         if (snapshot.get('isUnreviewed') && !snapshot.get('isUnchanged')) {
           acc.push(snapshot);

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -184,7 +184,8 @@ export default DS.Model.extend({
   },
 
   loadedSnapshots: computed(function() {
-    return this.store.peekAll('snapshot').filterBy('build.id', this.get('id'));
+    // Get snapshots without making new request
+    return this.hasMany('snapshots').value() || [];
   }),
 
   // Returns Ember Object with a property for each browser for the build,


### PR DESCRIPTION
##  [Clubhouse Card](https://app.clubhouse.io/percy/story/1967/do-not-reload-snapshots-more-than-necessary-when-viewing-a-build-page)

## Description
Loading a build page has been rather slow. This ended up being because snapshots for a build were being loaded multiple times due to implicit fetches from ember-data (ex: `build.get('snapshots')` triggers a load of _all_ snapshots for a build).

This PR tracks down all the places this was happening for the build page and loads the correct data at the correct time and gets the correct snapshots from the store.

This PR uses the `ds-references` methods to fetch data from the store without triggering a rebuild. It produces the same output as if we wrote: `this.get('store').peekAll('snapshot').filterBy('build.id', this.get('build.id'))`.

## Reviewing this PR
_**Is Covered by Automated Tests?: YES**_
No tests were updated, but the test scenarios cover this flow.

General review: does it seem weird? How did I do with Ember concurrency?

One problem remaining is: if you use the cached snapshots when switching browsers then expanding unchanged snapshots, the "loading unchanged snapshots" spinner does not display because it completes this operation in the same run loop. I have fixed this problem with a `run.later` around the meat of `toggleUnchangedSnapshotsVisible` but am disinclined to mess with Ember's run loop due to the difficulty it introduces to tests.