### PR TITLE
Rename visual validations to screenshots

### DIFF
--- a/app/templates/components/organizations/billing-section.hbs
+++ b/app/templates/components/organizations/billing-section.hbs
@@ -32,7 +32,7 @@
       <div class="text-gray-400 w-3/4">
         Current usage:
         {{#if organization.subscription.currentUsageStats}}
-          <strong class="text-gray-700">{{format-number organization.subscription.currentUsageStats.total}} visual validations</strong>
+          <strong class="text-gray-700">{{format-number organization.subscription.currentUsageStats.total}} screenshots</strong>
         {{else}}
           ...
         {{/if}}
@@ -51,7 +51,7 @@
 
         {{#if organization.subscription.plan.isFree}}
           <div class="Alert Alert--warning">
-            <strong>Your trial has expired.</strong> You're currently on the limited-use free plan, which provides {{subscriptionData.PLANS.[0].numWorkersTitle}} and {{subscriptionData.PLANS.[0].numDiffs}} visual validations. You can sign up for a plan below or feel free to <a href="#" {{action "showSupport"}}>reach out</a> with any questions!
+            <strong>Your trial has expired.</strong> You're currently on the limited-use free plan, which provides {{subscriptionData.PLANS.[0].numWorkersTitle}} and {{subscriptionData.PLANS.[0].numDiffs}} screenshots. You can sign up for a plan below or feel free to <a href="#" {{action "showSupport"}}>reach out</a> with any questions!
           </div>
         {{/if}}
 
@@ -67,7 +67,7 @@
                     <div>
                       <strong>
                         {{plan.workerLimit}} concurrent renderers
-                        {{format-number plan.usageIncluded}} visual validations
+                        {{format-number plan.usageIncluded}} screenshots
                       </strong>
                     </div>
                     <div>
@@ -108,7 +108,7 @@
                       {{planData.numWorkersTitle}}
                     </div>
                     <div>
-                      {{format-number planData.numDiffs}} visual validations
+                      {{format-number planData.numDiffs}} screenshots
                     </div>
                   </div>
                   <div style="max-width: 150px" class="flex-1 pr-2">
@@ -155,7 +155,7 @@
                   Custom concurrent renderers
                 </div>
                 <div>
-                  Unlimited visual validations
+                  Unlimited screenshots
                 </div>
               </div>
               <div class="flex-1 pr-2"></div>

--- a/app/templates/components/pricing-questions.hbs
+++ b/app/templates/components/pricing-questions.hbs
@@ -6,16 +6,11 @@
     </p>
     <h4>What are concurrent renderers?</h4>
     <p>
-      Percy is crafted to render your visual validations simultaneously in our custom parallel rendering infrastructure. The number of concurrent renderers is how many renderer processes are dedicated to your builds.
+      Percy is crafted to render your screenshots simultaneously in our custom parallel rendering infrastructure. The number of concurrent renderers is how many renderer processes are dedicated to your builds.
     </p>
-    {{!--
-    <h5>How many visual validations will my team use?</h5>
-    <p>
-    </p>
-    --}}
     <h4>What happens if I exceed the limits?</h4>
     <p>
-      Nothing! We simply charge a small fee for each extra visual validation over your monthly plan, but your builds and workflow will not be interrupted. Larger plans include significantly more visual validations and lower the fee for extra visual diffs.
+      Nothing! We simply charge a small fee for each extra visual validation over your monthly plan, but your builds and workflow will not be interrupted. Larger plans include significantly more screenshots and a lower fee for extras.
     </p>
   </div>
   <div class="one-half column">

--- a/app/templates/components/pricing-section.hbs
+++ b/app/templates/components/pricing-section.hbs
@@ -9,7 +9,7 @@
     </div>
     <hr>
     <div class="PricingSection-numTeamMembers">{{bucket.plan.numTeamMembersTitle}}</div>
-    <div class="PricingSection-diffs">{{format-number bucket.plan.numDiffs}} visual validations included</div>
+    <div class="PricingSection-diffs">{{format-number bucket.plan.numDiffs}} screenshots included</div>
     <div class="PricingSection-infoItem">${{bucket.plan.extraDiffPrice}} / extra visual validation</div>
     <div class="PricingSection-numWorkers"><br>{{bucket.plan.numWorkersTitle}}</div>
     <div class="PricingSection-infoItem">Awesome support</div>
@@ -26,7 +26,7 @@
     </div>
     <hr>
     <div class="PricingSection-numTeamMembers">{{bucket.plan.numTeamMembersTitle}}</div>
-    <div class="PricingSection-diffs">{{format-number bucket.plan.numDiffs}} visual validations included</div>
+    <div class="PricingSection-diffs">{{format-number bucket.plan.numDiffs}} screenshots included</div>
     <div class="PricingSection-infoItem">${{bucket.plan.extraDiffPrice}} / extra visual validation</div>
     <div class="PricingSection-numWorkers"><br>
       {{bucket.plan.numWorkersTitle}}
@@ -56,7 +56,7 @@ Most Percy builds finish in under 2 minutes.">
     {{!-- <div class="PricingSection-annualMonthlyPrice">${{format-number bucket.plan.annualMonthlyPrice}} if paid annually</div> --}}
     <hr>
     <div class="PricingSection-numTeamMembers">{{bucket.plan.numTeamMembersTitle}}</div>
-    <div class="PricingSection-diffs">{{format-number bucket.plan.numDiffs}} visual validations included</div>
+    <div class="PricingSection-diffs">{{format-number bucket.plan.numDiffs}} screenshots included</div>
     <div class="PricingSection-infoItem">${{bucket.plan.extraDiffPrice}} / extra visual validation</div>
     <div class="PricingSection-numWorkers"><br>{{bucket.plan.numWorkersTitle}}</div>
     <div class="PricingSection-infoItem">Awesome support</div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -83,7 +83,7 @@
     <figure class="svg-container mb-2">
       {{inline-svg "responsive"}}
     </figure>
-    <h3 class="text-xl md:text-2xl mb-1">Responsive visual validations</h3>
+    <h3 class="text-xl md:text-2xl mb-1">Responsive screenshots</h3>
     <p class="text-lg text-gray-400">Test your responsive designs — simply provide a list of breakpoint widths and we take care of the rest. See how CSS changes will affect your entire site, including on mobile devices. Easily catch mobile visual bugs before launch.</p>
   </div>
   <div>


### PR DESCRIPTION
Our pricing and billing pages currently include language around visual validations.  We've decided to swap this to screenshots, as it's easier to understand.