### PR TITLE
Auto-Approve: Show approval status in UI

### DIFF
--- a/app/controllers/organization/project/builds/build.js
+++ b/app/controllers/organization/project/builds/build.js
@@ -39,7 +39,7 @@ export default Controller.extend({
     browsers.forEach(browser => {
       const snapshotsWithDiffs = snapshotsWithDiffForBrowser(buildSnapshotsWithDiffs, browser);
       const sortedSnapshotsWithDiffs = snapshotSort(snapshotsWithDiffs.toArray(), browser);
-      const approvedSnapshots = sortedSnapshotsWithDiffs.filterBy('isApprovedByUserEver');
+      const approvedSnapshots = sortedSnapshotsWithDiffs.filterBy('isApprovedWithChanges');
       const unreviewedSnapshots = sortedSnapshotsWithDiffs.filterBy('isUnreviewed');
       orderedBrowserSnapshots[browser.get('id')] = [].concat(
         unreviewedSnapshots,

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -13,7 +13,7 @@ export const BUILD_STATES = {
 };
 
 const APPROVED_LABEL = 'Approved';
-const AUTO_APPROVED_BRANCH_LABEL = 'Auto-Approved Branch';
+const AUTO_APPROVED_BRANCH_LABEL = 'Auto Approved';
 const EXPIRED_LABEL = 'Expired';
 const FAILED_LABEL = 'Failed';
 const NO_DIFFS_LABEL = 'No Changes';

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -13,7 +13,7 @@ export const BUILD_STATES = {
 };
 
 const APPROVED_LABEL = 'Approved';
-const AUTO_APPROVED_BRANCH_LABEL = 'Auto Approved';
+const AUTO_APPROVED_BRANCH_LABEL = 'Auto-Approved';
 const EXPIRED_LABEL = 'Expired';
 const FAILED_LABEL = 'Failed';
 const NO_DIFFS_LABEL = 'No Changes';

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -12,13 +12,14 @@ export const BUILD_STATES = {
   EXPIRED: 'expired',
 };
 
+const APPROVED_LABEL = 'Approved';
+const AUTO_APPROVED_BRANCH_LABEL = 'Auto-Approved Branch';
+const EXPIRED_LABEL = 'Expired';
+const FAILED_LABEL = 'Failed';
+const NO_DIFFS_LABEL = 'No Changes';
 const PENDING_LABEL = 'Receiving';
 const PROCESSING_LABEL = 'Processing';
 const UNREVIEWED_LABEL = 'Unreviewed';
-const APPROVED_LABEL = 'Approved';
-const NO_DIFFS_LABEL = 'No Changes';
-const FAILED_LABEL = 'Failed';
-const EXPIRED_LABEL = 'Expired';
 
 export default DS.Model.extend({
   project: DS.belongsTo('project', {async: false}),
@@ -78,6 +79,7 @@ export default DS.Model.extend({
   //   because a user had previously approved the same snapshots in this branch.
   // - 'approved' --> 'no_diffs': All snapshots were automatically approved because there were no
   //    visual differences when compared with the baseline.
+  // - 'approved' --> 'auto_approved_branch': Automatically approved based on branch name
   reviewStateReason: DS.attr(),
 
   // Aggregate numbers for snapshots and comparisons. These will only be set for finished builds.
@@ -123,6 +125,8 @@ export default DS.Model.extend({
       if (this.get('isApproved')) {
         if (this.get('reviewStateReason') === 'no_diffs') {
           return NO_DIFFS_LABEL;
+        } else if (this.get('reviewStateReason') === 'auto_approved_branch') {
+          return AUTO_APPROVED_BRANCH_LABEL;
         } else {
           return APPROVED_LABEL;
         }

--- a/app/models/snapshot.js
+++ b/app/models/snapshot.js
@@ -53,6 +53,10 @@ export default DS.Model.extend({
     'reviewStateReason',
     SNAPSHOT_REVIEW_STATE_REASONS.USER_APPROVED_PREVIOUSLY,
   ),
+  isAutoApprovedBranch: equal(
+    'reviewStateReason',
+    SNAPSHOT_REVIEW_STATE_REASONS.AUTO_APPROVED_BRANCH,
+  ),
   isUnchanged: equal('reviewStateReason', SNAPSHOT_REVIEW_STATE_REASONS.NO_DIFFS),
 
   // Is true for both approved in build and approved by carry-forward.

--- a/app/models/snapshot.js
+++ b/app/models/snapshot.js
@@ -6,14 +6,16 @@ export const SNAPSHOT_APPROVED_STATE = 'approved';
 export const SNAPSHOT_UNAPPROVED_STATE = 'unreviewed';
 
 export const SNAPSHOT_REVIEW_STATE_REASONS = {
+  AUTO_APPROVED_BRANCH: 'auto_approved_branch',
+  NO_DIFFS: 'no_diffs',
   UNREVIEWED: 'unreviewed_comparisons',
   USER_APPROVED: 'user_approved',
   USER_APPROVED_PREVIOUSLY: 'user_approved_previously',
-  NO_DIFFS: 'no_diffs',
 };
 
 // These are the possible reviewStateReasons for snapshots that have diffs
 export const DIFF_REVIEW_STATE_REASONS = [
+  SNAPSHOT_REVIEW_STATE_REASONS.AUTO_APPROVED_BRANCH,
   SNAPSHOT_REVIEW_STATE_REASONS.UNREVIEWED,
   SNAPSHOT_REVIEW_STATE_REASONS.USER_APPROVED,
   SNAPSHOT_REVIEW_STATE_REASONS.USER_APPROVED_PREVIOUSLY,
@@ -44,6 +46,7 @@ export default DS.Model.extend({
   //    approved the same thing in this branch.
   // - 'approved' --> 'no_diffs': automatically approved because there were no visual differences
   //    when compared the baseline.
+  // - 'approved' --> 'auto_approved_branch': Automatically approved based on branch name
   reviewStateReason: DS.attr(),
   isApprovedByUser: equal('reviewStateReason', SNAPSHOT_REVIEW_STATE_REASONS.USER_APPROVED),
   isApprovedByUserPreviously: equal(

--- a/app/models/snapshot.js
+++ b/app/models/snapshot.js
@@ -59,8 +59,12 @@ export default DS.Model.extend({
   ),
   isUnchanged: equal('reviewStateReason', SNAPSHOT_REVIEW_STATE_REASONS.NO_DIFFS),
 
-  // Is true for both approved in build and approved by carry-forward.
-  isApprovedByUserEver: or('isApprovedByUser', 'isApprovedByUserPreviously'),
+  // Is true for approved in build, approved by carry-forward, and auto-approved by branch.
+  isApprovedWithChanges: or(
+    'isApprovedByUser',
+    'isApprovedByUserPreviously',
+    'isAutoApprovedBranch',
+  ),
 
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),

--- a/app/templates/components/build-overview.hbs
+++ b/app/templates/components/build-overview.hbs
@@ -11,6 +11,8 @@
           All changes approved
         {{else if (eq build.reviewStateReason 'all_snapshots_approved_previously')}}
           All changes approved
+        {{else if (eq build.reviewStateReason 'auto_approved_branch')}}
+          All changes approved automatically on {{build.branch}}
         {{else if (eq build.reviewStateReason 'no_diffs')}}
           No changes to review
         {{/if}}

--- a/app/templates/components/build-overview.hbs
+++ b/app/templates/components/build-overview.hbs
@@ -12,7 +12,7 @@
         {{else if (eq build.reviewStateReason 'all_snapshots_approved_previously')}}
           All changes approved
         {{else if (eq build.reviewStateReason 'auto_approved_branch')}}
-          All changes approved automatically on {{build.branch}}
+          All changes approved automatically on this branch
         {{else if (eq build.reviewStateReason 'no_diffs')}}
           No changes to review
         {{/if}}

--- a/app/templates/components/forms/project-edit.hbs
+++ b/app/templates/components/forms/project-edit.hbs
@@ -17,23 +17,21 @@
     </div>
   </div>
 
-  {{#if (is-admin)}}
-    <h2 class="text-xl font-semibold mt-3 mb-sm">Auto-Approve Branches</h2>
-    <p class="text-gray-400 mb-2">
-      Builds with branches that match this filter will be automatically approved and won't require
-      manual approval.
-    </p>
-    <div class="px-2 pt-2 bg-gray-000 rounded border mb-2">
-      {{form-fields/input
-        property="autoApproveBranchFilter"
-        title="Branch filter pattern"
-        changeset=changeset
-      }}
-      <div class="rounded border p-2 mb-2">
-        <strong>Note:</strong> Separate multiple branches with spaces. You can use <code>*</code> as a wildcard match. Example: <code>master staging-* release-*.*.*</code>
-      </div>
+  <h2 class="text-xl font-semibold mt-3 mb-sm">Auto-Approve Branches</h2>
+  <p class="text-gray-400 mb-2">
+    Builds with branches that match this filter will be automatically approved and won't require
+    manual approval.
+  </p>
+  <div class="px-2 pt-2 bg-gray-000 rounded border mb-2">
+    {{form-fields/input
+      property="autoApproveBranchFilter"
+      title="Branch filter pattern"
+      changeset=changeset
+    }}
+    <div class="rounded border p-2 mb-2">
+      <strong>Note:</strong> Separate multiple branches with spaces. You can use <code>*</code> as a wildcard match. Example: <code>master staging-* release-*.*.*</code>
     </div>
-  {{/if}}
+  </div>
   <div class="flex justify-end">
     {{form-fields/submit
       isSaving=isSaving

--- a/app/templates/components/snapshot-approval-button.hbs
+++ b/app/templates/components/snapshot-approval-button.hbs
@@ -2,6 +2,8 @@
   <div class="status-pill {{if snapshot.isUnchanged 'is-unchanged' 'is-approved'}}" data-test-snapshot-approved-pill>
     {{#if snapshot.isUnchanged}}
       No Changes
+    {{else if snapshot.isAutoApprovedBranch}}
+      Auto-Approved
     {{else}}
       Approved
     {{/if}}

--- a/mirage/factories/build.js
+++ b/mirage/factories/build.js
@@ -42,6 +42,12 @@ export default Factory.extend({
     totalComparisonsDiff: 0,
   }),
 
+  approvedAutoBranch: trait({
+    state: BUILD_STATES.FINISHED,
+    reviewState: 'approved',
+    reviewStateReason: 'auto_approved_branch',
+  }),
+
   pending: trait({
     state: BUILD_STATES.PENDING,
   }),

--- a/mirage/factories/build.js
+++ b/mirage/factories/build.js
@@ -42,12 +42,6 @@ export default Factory.extend({
     totalComparisonsDiff: 0,
   }),
 
-  approvedAutoBranch: trait({
-    state: BUILD_STATES.FINISHED,
-    reviewState: 'approved',
-    reviewStateReason: 'auto_approved_branch',
-  }),
-
   pending: trait({
     state: BUILD_STATES.PENDING,
   }),

--- a/mirage/factories/build.js
+++ b/mirage/factories/build.js
@@ -46,6 +46,9 @@ export default Factory.extend({
     state: BUILD_STATES.FINISHED,
     reviewState: 'approved',
     reviewStateReason: 'auto_approved_branch',
+    afterCreate(build, server) {
+      server.create('snapshot', 'autoApprovedBranch', {build});
+    },
   }),
 
   pending: trait({

--- a/mirage/factories/snapshot.js
+++ b/mirage/factories/snapshot.js
@@ -17,10 +17,13 @@ const _userApprovedPreviouslyProps = {
   reviewState: SNAPSHOT_APPROVED_STATE,
   reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.USER_APPROVED_PREVIOUSLY,
 };
-
 const _noDiffProps = {
   reviewState: SNAPSHOT_APPROVED_STATE,
   reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.NO_DIFFS,
+};
+const _autoApprovedBranchProps = {
+  reviewState: SNAPSHOT_APPROVED_STATE,
+  reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.AUTO_APPROVED_BRANCH,
 };
 
 export default Factory.extend({
@@ -66,6 +69,15 @@ export default Factory.extend({
       afterCreate(snapshot, server) {
         _addComparisonIds(server.create('comparison'), snapshot);
         _addComparisonIds(server.create('comparison', 'forChrome'), snapshot);
+      },
+    }),
+  ),
+
+  autoApprovedBranch: trait(
+    Object.assign({}, _autoApprovedBranchProps, {
+      afterCreate(snapshot, server) {
+        const comparison = server.create('comparison');
+        _addComparisonIds(comparison, snapshot);
       },
     }),
   ),

--- a/mirage/factories/snapshot.js
+++ b/mirage/factories/snapshot.js
@@ -23,11 +23,6 @@ const _noDiffProps = {
   reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.NO_DIFFS,
 };
 
-const _autoApprovedBranchProps = {
-  reviewState: SNAPSHOT_APPROVED_STATE,
-  reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.AUTO_APPROVED_BRANCH,
-};
-
 export default Factory.extend({
   id(i) {
     return `snapshot-${i}`;
@@ -39,8 +34,6 @@ export default Factory.extend({
   unreviewed: trait(_unreviewedProps),
   userApproved: trait(_userApprovedProps),
   userApprovedPreviously: trait(_userApprovedPreviouslyProps),
-
-  autoApprovedBranch: trait(_autoApprovedBranchProps),
 
   withComparison: trait(
     Object.assign({}, _unreviewedProps, {

--- a/mirage/factories/snapshot.js
+++ b/mirage/factories/snapshot.js
@@ -23,6 +23,11 @@ const _noDiffProps = {
   reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.NO_DIFFS,
 };
 
+const _autoApprovedBranchProps = {
+  reviewState: SNAPSHOT_APPROVED_STATE,
+  reviewStateReason: SNAPSHOT_REVIEW_STATE_REASONS.AUTO_APPROVED_BRANCH,
+};
+
 export default Factory.extend({
   id(i) {
     return `snapshot-${i}`;
@@ -34,6 +39,8 @@ export default Factory.extend({
   unreviewed: trait(_unreviewedProps),
   userApproved: trait(_userApprovedProps),
   userApprovedPreviously: trait(_userApprovedPreviouslyProps),
+
+  autoApprovedBranch: trait(_autoApprovedBranchProps),
 
   withComparison: trait(
     Object.assign({}, _unreviewedProps, {

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -425,6 +425,30 @@ describe('Acceptance: Fullscreen Snapshot', function() {
   });
 });
 
+describe('Acceptance: Auto-Approved Branch Build', function() {
+  setupAcceptance();
+  let urlParams;
+
+  setupSession(function(server) {
+    let organization = server.create('organization', 'withUser');
+    let project = server.create('project', {name: 'auto-approved-branch build', organization});
+    let build = server.create('build', 'approvedAutoBranch', {project});
+
+    urlParams = {
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+      buildId: build.id,
+    };
+  });
+
+  it('shows as auto-approved', async function() {
+    await BuildPage.visitBuild(urlParams);
+    expect(currentPath()).to.equal('organization.project.builds.build.index');
+
+    await percySnapshot(this.test.fullTitle() + ' on the build page');
+  });
+});
+
 describe('Acceptance: Pending Build', function() {
   freezeMoment('2018-05-22');
   setupAcceptance();

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -68,6 +68,8 @@ describe('Acceptance: Build', function() {
     await BuildPage.snapshotList.clickToggleNoDiffsSection();
     expect(BuildPage.snapshots().count).to.equal(6);
     expect(store.peekAll('snapshot').get('length')).to.equal(7);
+
+    await percySnapshot(this.test);
   });
 
   describe('snapshot order/caching', function() {

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -57,16 +57,17 @@ describe('Acceptance: Build', function() {
     // add some snapshots (to the four above) to cover every review state reason.
     server.create('snapshot', 'withComparison', 'userApproved', {build});
     server.create('snapshot', 'withComparison', 'userApprovedPreviously', {build});
+    server.create('snapshot', 'withComparison', 'autoApprovedBranch', {build});
 
     await BuildPage.visitBuild(urlParams);
     const store = this.application.__container__.lookup('service:store');
     expect(BuildPage.snapshots().count).to.equal(5);
     expect(BuildPage.isUnchangedPanelVisible).to.equal(true);
-    expect(store.peekAll('snapshot').get('length')).to.equal(5);
+    expect(store.peekAll('snapshot').get('length')).to.equal(6);
 
     await BuildPage.snapshotList.clickToggleNoDiffsSection();
     expect(BuildPage.snapshots().count).to.equal(6);
-    expect(store.peekAll('snapshot').get('length')).to.equal(6);
+    expect(store.peekAll('snapshot').get('length')).to.equal(7);
   });
 
   describe('snapshot order/caching', function() {

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -69,16 +69,6 @@ describe('Acceptance: Build', function() {
     expect(store.peekAll('snapshot').get('length')).to.equal(6);
   });
 
-  it('shows Auto-Approved diffs', async function() {
-    server.create('snapshot', 'withComparison', 'autoApprovedBranch', {build});
-    server.create('snapshot', 'withComparison', 'autoApprovedBranch', {build});
-
-    await BuildPage.visitBuild(urlParams);
-    expect(BuildPage.snapshots().count).to.equal(3);
-
-    await percySnapshot(this.test);
-  });
-
   describe('snapshot order/caching', function() {
    it('displays snapshots in the correct order, before and after approval when build is finished', async function() { // eslint-disable-line
 

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -57,17 +57,24 @@ describe('Acceptance: Build', function() {
     // add some snapshots (to the four above) to cover every review state reason.
     server.create('snapshot', 'withComparison', 'userApproved', {build});
     server.create('snapshot', 'withComparison', 'userApprovedPreviously', {build});
-    server.create('snapshot', 'withComparison', 'autoApprovedBranch', {build});
 
     await BuildPage.visitBuild(urlParams);
     const store = this.application.__container__.lookup('service:store');
     expect(BuildPage.snapshots().count).to.equal(5);
     expect(BuildPage.isUnchangedPanelVisible).to.equal(true);
-    expect(store.peekAll('snapshot').get('length')).to.equal(6);
+    expect(store.peekAll('snapshot').get('length')).to.equal(5);
 
     await BuildPage.snapshotList.clickToggleNoDiffsSection();
     expect(BuildPage.snapshots().count).to.equal(6);
-    expect(store.peekAll('snapshot').get('length')).to.equal(7);
+    expect(store.peekAll('snapshot').get('length')).to.equal(6);
+  });
+
+  it('shows Auto-Approved diffs', async function() {
+    server.create('snapshot', 'withComparison', 'autoApprovedBranch', {build});
+    server.create('snapshot', 'withComparison', 'autoApprovedBranch', {build});
+
+    await BuildPage.visitBuild(urlParams);
+    expect(BuildPage.snapshots().count).to.equal(3);
 
     await percySnapshot(this.test);
   });

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -161,6 +161,7 @@ describe('Acceptance: Project', function() {
       server.create('build', 'approved', {project, createdAt: _timeAgo(5, 'minutes')});
       server.create('build', 'approvedPreviously', {project, createdAt: _timeAgo(4, 'minutes')});
       server.create('build', 'approvedWithNoDiffs', {project, createdAt: _timeAgo(2, 'minutes')});
+      server.create('build', 'approvedAutoBranch', {project, createdAt: _timeAgo(3, 'minutes')});
       server.create('build', 'processing', {project, createdAt: _timeAgo(10, 'seconds')});
       this.project = project;
     });


### PR DESCRIPTION
##  [Clubhouse Card](https://app.clubhouse.io/percy/story/2019/auto-approve-branches-set-approval-state-on-matching-builds)

## Description
This is the final part of the greater Auto-Approve story. In this iteration, we show the auto-approved-branch reason to the user when they are viewing snapshots and builds.

## Pictures
(see Percy snapshots)

## Reviewing this PR

_**Is Covered by Automated Tests?: YES**_

Reviewer Notes:
- Take a look at the *wording* of things in the UI.
- Take a look at my usage of mirage and acceptance test changes.