### PR TITLE
Remove references to images/pattern-on-white.svg

### DIFF
--- a/app/styles/components/_browser_family_selector.scss
+++ b/app/styles/components/_browser_family_selector.scss
@@ -9,7 +9,7 @@
 
 .browser-family-selector {
   &:hover:not(.is-browser-active) {
-    background: url("/images/pattern-on-white.svg"), var(--blue-000);
+    background-color: var(--blue-000);
     border: 1px solid var(--blue-500);
     box-shadow: 0 0 16px rgba(29, 141, 219, 0.2);
     animation: move-background 8s linear infinite;
@@ -41,7 +41,7 @@
   }
 
   &.is-browser-active {
-    background: url("/images/pattern-on-white.svg"), var(--purple-200);
+    background-color: var(--purple-200);
     border-color: var(--purple-600);
   }
 

--- a/app/templates/components/projects/browser-family-selector-button.hbs
+++ b/app/templates/components/projects/browser-family-selector-button.hbs
@@ -1,5 +1,5 @@
     <div
-      class="browser-family-selector overflow-hidden cursor-pointer flex justify-center bg-white-pattern border border-transparent rounded p-3 shadow-1 {{if isBrowserEnabled "is-browser-active"}} {{concat "data-test-browser-selector-" family.slug}}"
+      class="browser-family-selector overflow-hidden cursor-pointer flex justify-center border border-transparent rounded p-3 shadow-1 {{if isBrowserEnabled "is-browser-active"}} {{concat "data-test-browser-selector-" family.slug}}"
       {{action updateProjectBrowserTargets family}}
       data-test-browser-selector-button>
       <div class="browser-family-selector-detail flex flex-col items-center">


### PR DESCRIPTION
## Description
Something in Safari is _very_ confused about `pattern-on-white.svg`. It refetches the `pattern-on-white.svg` image many times per second as it is in production. This behavior starts when hovering over a button.

This update removes references to `pattern-on-white.svg` for now, and just uses the nice highlighting colors.

## Pictures
### Before
![before-browser-css-fix](https://user-images.githubusercontent.com/3179218/42006626-cca41c70-7a2f-11e8-8b14-61f73f8745b6.gif)

### After
![browser-fix](https://user-images.githubusercontent.com/3179218/42006618-c54ead5a-7a2f-11e8-9427-1f127350f3e0.gif)

## Reviewing this PR
Are we willing to say goodbye to @PixelJanitor's absolutely epic wizardry?
_**Is Covered by Automated Tests?: NO **_ -- No safari support :(
