### PR TITLE
Proof of concept: Contentful srcset

### DIFF
--- a/app/adapters/src-set.js
+++ b/app/adapters/src-set.js
@@ -1,0 +1,3 @@
+import ContentfulAdapter from 'ember-data-contentful/adapters/contentful';
+
+export default ContentfulAdapter.extend({});

--- a/app/components/marketing/src-set-image.js
+++ b/app/components/marketing/src-set-image.js
@@ -1,0 +1,26 @@
+import Component from '@ember/component';
+import {computed} from '@ember/object';
+import {readOnly} from '@ember/object/computed';
+
+export default Component.extend({
+  srcSet: null,
+  windowSize: 0,
+
+  init() {
+    this._super(...arguments);
+    this.set('windowSize', window.innerWidth);
+    window.addEventListener('resize', () => {
+      this.set('windowSize', window.innerWidth);
+    });
+  },
+
+  defaultImageWidth: readOnly('srcSet.defaultImage.file.details.image.width'),
+
+  imgSrc: computed('windowSize', function() {
+    if (this.get('windowSize') > this.get('defaultImageWidth')) {
+      return this.get('srcSet.largeImageUrl');
+    } else {
+      return this.get('srcSet.defaultImage.file.url');
+    }
+  }),
+});

--- a/app/models/src-set.js
+++ b/app/models/src-set.js
@@ -1,0 +1,10 @@
+import Contentful from 'ember-data-contentful/models/contentful';
+import attr from 'ember-data/attr';
+import DS from 'ember-data';
+
+export default Contentful.extend({
+  contentType: 'srcSet',
+
+  defaultImage: DS.belongsTo('contentful-asset'), // model here: https://bit.ly/2MoN7fD
+  largeImageUrl: attr(),
+});

--- a/app/router.js
+++ b/app/router.js
@@ -56,6 +56,7 @@ Router.map(function() {
   this.route('pricing');
   this.route('enterprise');
   this.route('team');
+  this.route('testzz');
   this.route('about'); // Redirects to team in route.
   this.route('terms');
   this.route('privacy');

--- a/app/routes/testzz.js
+++ b/app/routes/testzz.js
@@ -1,0 +1,13 @@
+import MarketingPageBaseRoute from 'percy-web/routes/marketing-page-base';
+
+export default MarketingPageBaseRoute.extend({
+  model() {
+    return this.store.findAll('src-set').then(srcSets => {
+      return srcSets.get('firstObject');
+    });
+  },
+
+  setupController(controller, resolvedModel) {
+    controller.set('srcSet', resolvedModel);
+  },
+});

--- a/app/serializers/src-set.js
+++ b/app/serializers/src-set.js
@@ -1,0 +1,3 @@
+import ContentfulSerializer from 'ember-data-contentful/serializers/contentful';
+
+export default ContentfulSerializer.extend({});

--- a/app/templates/components/marketing/src-set-image.hbs
+++ b/app/templates/components/marketing/src-set-image.hbs
@@ -1,0 +1,1 @@
+<img src={{imgSrc}}>

--- a/app/templates/testzz.hbs
+++ b/app/templates/testzz.hbs
@@ -1,0 +1,1 @@
+{{marketing/src-set-image srcSet=srcSet}}


### PR DESCRIPTION
This POC introduces a `srcset` model which has two fields:

Default image: this image will be the small version of the image and always load.
Large image url: this is the contentful location for the large image. 

The component watches the browser width and recalculates whether it should show the large or small image.

The window width in this case could be a proxy for the element width, but unless the element has a width before the image is loaded, the width may come back as zero...maybe we could get the parent's width? Anyway, up for debate.

Pros:
- Looks like we have srcsets.

Cons:
- We always load the small image, whether or not we need it.
- We make an extra request for each large image (it is not included in the initial contentful request)
- We use a lot of browser effort listening for window resize.


