### PR TITLE
Remove GitLab beta label

### DIFF
--- a/app/lib/integration-types.js
+++ b/app/lib/integration-types.js
@@ -34,7 +34,7 @@ export const INTEGRATION_TYPES = {
   },
   [GITLAB_SELF_HOSTED_INTEGRATION_TYPE]: {
     textName: 'GitLab Self-Hosted',
-    isBeta: true,
+    isBeta: false,
     isGeneralAvailability: true,
     betaLink: 'https://docs.percy.io/docs/gitlab-self-hosted',
     iconName: 'gitlab-icon-lg',


### PR DESCRIPTION
[Clubhouse Card](https://app.clubhouse.io/percy/story/2407/remove-beta-label)

Description
===

Remove beta label from GitLab Self-managed integration