### PR TITLE
update team transition to

### DIFF
--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -1,5 +1,6 @@
 {{title "Team"}}
 {{marketing/marketing-page
+  transitionTo=(route-action "transitionTo")
   page=model}}
 
 <section id="current-openings" class="container-full bg-purple-gradient-pattern py-8">


### PR DESCRIPTION
The marketing page component requires a `transitionTo` action and the team page doesn't give it one. Now it does. It has caused a couple of errors: https://sentry.io/percy/prod-web/issues/736566174/