### PR TITLE
Allow Slack notifications to be branch-specific

### DIFF
--- a/app/components/organizations/integrations/slack-config-item.js
+++ b/app/components/organizations/integrations/slack-config-item.js
@@ -8,6 +8,7 @@ export default Component.extend({
   slackIntegrationConfig: null,
   projectOptions: null,
 
+  branch: alias('slackIntegrationConfig.branch'),
   notificationTypes: alias('slackIntegrationConfig.notificationTypes'),
   notificationLabels: computed('notificationTypes', function () {
     return this.notificationTypes.map(function (setting) {

--- a/app/models/slack-integration-config.js
+++ b/app/models/slack-integration-config.js
@@ -36,4 +36,7 @@ export default class SlackIntegrationConfig extends Model {
 
   @attr()
   notificationTypes;
+
+  @attr()
+  branch;
 }

--- a/app/templates/components/forms/slack-integration-config.hbs
+++ b/app/templates/components/forms/slack-integration-config.hbs
@@ -61,6 +61,13 @@
           @allOptions={{this.slackNotificationOptions}}
         />
 
+        <FormFields::Input
+          @property="branch"
+          @title="Optional: Specify branch"
+          @subtitle="To only send notifications for a specific code branch, enter a branch name. Must be an exact match."
+          @changeset={{this.changeset}}
+        />
+
         {{#if this.errorMessage}}
           <div class="Form-errors">
             {{this.errorMessage}}

--- a/app/templates/components/forms/slack-integration-config.hbs
+++ b/app/templates/components/forms/slack-integration-config.hbs
@@ -63,8 +63,8 @@
 
         <FormFields::Input
           @property="branch"
-          @title="Optional: Specify branch"
-          @subtitle="To only send notifications for a specific code branch, enter a branch name. Must be an exact match."
+          @title="Specify branch (optional)"
+          @subtitle="Enter a branch name to send notifications for a specified branch. When left blank, Percy will send notifications for all branches."
           @changeset={{this.changeset}}
         />
 

--- a/app/templates/components/organizations/integrations/slack-config-item.hbs
+++ b/app/templates/components/organizations/integrations/slack-config-item.hbs
@@ -3,20 +3,32 @@
     <div class="flex justify-start items-center">
       <div>
         <div class="flex justify-start items-center">
-          <div class="text-lg font-semibold mr-2" data-test-project-name>
+          <div class="text-lg font-semibold mr-2 whitespace-no-wrap" data-test-project-name>
             {{this.projectName}}
           </div>
           <div class="flex-shrink">
             <div>
               {{#each this.notificationLabels as |type|}}
-                <code class="mr-1 lowercase" data-test-notification-type>{{type}}</code>
+                <code
+                  style="display: inline-block; padding: 2px 8px;"
+                  class="
+                    status-pill
+                    font-sans
+                    mr-1
+                    my-sm
+                    {{if (or (eq type 'Approved') (eq type 'Auto-approved')) 'is-approved'}}
+                    {{if (eq type 'Unreviewed & Changes requested') 'is-unreviewed'}}
+                    {{if (eq type 'No changes') 'is-unchanged'}}"
+                  data-test-notification-type>
+                  {{type}}
+                </code>
               {{/each}}
             </div>
             {{#if this.branch}}
-            <div>
-              <span class="whitespace-no-wrap font-semibold ml-1 mt-1">Branch</span>
-              <code>{{this.branch}}</code>
-            </div>
+              <div class="mt-1">
+                <span class="whitespace-no-wrap font-semibold">Branch:</span>
+                <code>{{this.branch}}</code>
+              </div>
             {{/if}}
           </div>
         </div>

--- a/app/templates/components/organizations/integrations/slack-config-item.hbs
+++ b/app/templates/components/organizations/integrations/slack-config-item.hbs
@@ -7,9 +7,17 @@
             {{this.projectName}}
           </div>
           <div class="flex-shrink">
-            {{#each this.notificationLabels as |type|}}
-              <code class="mr-1 lowercase" data-test-notification-type>{{type}}</code>
-            {{/each}}
+            <div>
+              {{#each this.notificationLabels as |type|}}
+                <code class="mr-1 lowercase" data-test-notification-type>{{type}}</code>
+              {{/each}}
+            </div>
+            {{#if this.branch}}
+            <div>
+              <span class="whitespace-no-wrap font-semibold ml-1 mt-1">Branch</span>
+              <code>{{this.branch}}</code>
+            </div>
+            {{/if}}
           </div>
         </div>
       </div>

--- a/app/templates/components/organizations/integrations/slack-integration-item.hbs
+++ b/app/templates/components/organizations/integrations/slack-integration-item.hbs
@@ -29,7 +29,7 @@
         @models={{array this.slackIntegration.organization.id this.slackIntegration.id "new"}}
       >
         <button type="button" class="percy-btn percy-btn-primary" data-test-add-project-button>
-          Add project
+          Add project rule
         </button>
       </LinkTo>
     </div>

--- a/tests/acceptance/slack-integration-test.js
+++ b/tests/acceptance/slack-integration-test.js
@@ -128,7 +128,8 @@ describe('Acceptance: Slack Integration', function () {
     describe('with an integration with configs', function () {
       beforeEach(function () {
         const slackIntegration = server.create('slackIntegration', {organization});
-        server.createList('slackIntegrationConfig', 2, {slackIntegration});
+        server.create('slackIntegrationConfig', {slackIntegration});
+        server.create('slackIntegrationConfig', {slackIntegration, branch: 'master'});
         server.create('slackIntegrationConfig', {
           slackIntegration,
           projectId: server.create('project', {organization}).id,
@@ -283,7 +284,8 @@ describe('Acceptance: Slack Integration', function () {
       describe('Slack config form', function () {
         it('does not render', async function () {
           await visit(
-            `/organizations/${organization.slug}/integrations/slack/${ // eslint-disable-line
+            `/organizations/${organization.slug}/integrations/slack/${
+              // eslint-disable-line
               slackIntegration.id
             }/configs/new`,
           );


### PR DESCRIPTION
##  [Clubhouse Card](www.Your_Clubhouse_Link_Here.com)

## Description
This allows slack configurations to specify a branch. This is particularly useful if a QA team wants notifications about every change to the 'develop' branch and does not care about changes to other branches.



## Reviewing this PR
<!--
Indicate if automated tests cover this PR. If not EXPLAIN WHY
-->
_**Is Covered by Automated Tests?: YES**_ There is visual test coverage

<!--
Let other developers know how to review this PR. If there's a required manual or local testing process, document it here. Also call out any ideas in your code that you would like other developers to weigh in on, such as broad concepts or patterns you used across files.
-->
